### PR TITLE
Right and bottom are now as CSS properties, offset from superview right and bottom edges

### DIFF
--- a/PinLayout/Helpers/Coordinates.swift
+++ b/PinLayout/Helpers/Coordinates.swift
@@ -29,11 +29,11 @@ import UIKit
 
 internal class Coordinates {
     static func top(_ view: UIView) -> CGFloat {
-        return view.frame.origin.y
+        return view.frame.minY
     }
 
     static func left(_ view: UIView) -> CGFloat {
-        return view.frame.origin.x
+        return view.frame.minX
     }
 
     static func bottom(_ view: UIView) -> CGFloat {
@@ -45,38 +45,38 @@ internal class Coordinates {
     }
 
     static func hCenter(_ view: UIView) -> CGFloat {
-        return view.frame.origin.x + (view.frame.size.width / 2)
+        return view.frame.minX + (view.frame.width / 2)
     }
 
     static func vCenter(_ view: UIView) -> CGFloat {
-        return view.frame.origin.y + (view.frame.size.height / 2)
+        return view.frame.minY + (view.frame.height / 2)
     }
 
 //    static func size(_ view: UIView) -> CGSize {
 //        return view.frame.size
 //    }
 //    static func width(_ view: UIView) -> CGFloat {
-//        return view.frame.size.width
+//        return view.frame.width
 //    }
 //
 //    static func height(_ view: UIView) -> CGFloat {
-//        return view.frame.size.height
+//        return view.frame.height
 //    }
 
     static func topLeft(_ view: UIView) -> CGPoint {
-        return CGPoint(x: view.frame.origin.x, y: view.frame.origin.y)
+        return CGPoint(x: view.frame.minX, y: view.frame.minY)
     }
 
     static func topCenter(_ view: UIView) -> CGPoint {
-        return CGPoint(x: hCenter(view), y: view.frame.origin.y)
+        return CGPoint(x: hCenter(view), y: view.frame.minY)
     }
 
     static func topRight(_ view: UIView) -> CGPoint {
-        return CGPoint(x: view.frame.origin.x + view.frame.size.width, y: view.frame.origin.y)
+        return CGPoint(x: view.frame.minX + view.frame.width, y: view.frame.minY)
     }
 
     static func rightCenter(_ view: UIView) -> CGPoint {
-        return CGPoint(x: view.frame.origin.x + view.frame.size.width, y: vCenter(view))
+        return CGPoint(x: view.frame.minX + view.frame.width, y: vCenter(view))
     }
 
     static func center(_ view: UIView) -> CGPoint {
@@ -84,19 +84,19 @@ internal class Coordinates {
     }
 
     static func leftCenter(_ view: UIView) -> CGPoint {
-        return CGPoint(x: view.frame.origin.x, y: vCenter(view))
+        return CGPoint(x: view.frame.minX, y: vCenter(view))
     }
 
     static func bottomLeft(_ view: UIView) -> CGPoint {
-        return CGPoint(x: view.frame.origin.x, y: view.frame.origin.y + view.frame.size.height)
+        return CGPoint(x: view.frame.minX, y: view.frame.minY + view.frame.height)
     }
 
     static func bottomCenter(_ view: UIView) -> CGPoint {
-        return CGPoint(x: hCenter(view), y: view.frame.origin.y + view.frame.size.height)
+        return CGPoint(x: hCenter(view), y: view.frame.minY + view.frame.height)
     }
 
     static func bottomRight(_ view: UIView) -> CGPoint {
-        return CGPoint(x: view.frame.origin.x + view.frame.size.width, y: view.frame.origin.y + view.frame.size.height)
+        return CGPoint(x: view.frame.minX + view.frame.width, y: view.frame.minY + view.frame.height)
     }
 
     static let displayScale = UIScreen.main.scale

--- a/PinLayout/PinLayout.swift
+++ b/PinLayout/PinLayout.swift
@@ -125,45 +125,38 @@ public protocol PinLayout {
     @discardableResult func left(_ value: CGFloat) -> PinLayout
     @discardableResult func bottom(_ value: CGFloat) -> PinLayout
     @discardableResult func right(_ value: CGFloat) -> PinLayout
+    @discardableResult func hCenter(_ value: CGFloat) -> PinLayout
+    @discardableResult func vCenter(_ value: CGFloat) -> PinLayout
 
     @discardableResult func top(to edge: VerticalEdge) -> PinLayout
     @discardableResult func left(to edge: HorizontalEdge) -> PinLayout
     @discardableResult func bottom(to edge: VerticalEdge) -> PinLayout
     @discardableResult func right(to edge: HorizontalEdge) -> PinLayout
     
-    @discardableResult func topLeft(to point: CGPoint) -> PinLayout
     @discardableResult func topLeft(to anchor: Anchor) -> PinLayout
     @discardableResult func topLeft() -> PinLayout
 
-    @discardableResult func topCenter(to point: CGPoint) -> PinLayout
     @discardableResult func topCenter(to anchor: Anchor) -> PinLayout
     @discardableResult func topCenter() -> PinLayout
 
-    @discardableResult func topRight(to point: CGPoint) -> PinLayout
     @discardableResult func topRight(to anchor: Anchor) -> PinLayout
     @discardableResult func topRight() -> PinLayout
 
-    @discardableResult func leftCenter(to point: CGPoint) -> PinLayout
     @discardableResult func leftCenter(to anchor: Anchor) -> PinLayout
     @discardableResult func leftCenter() -> PinLayout
 
-    @discardableResult func center(to point: CGPoint) -> PinLayout
     @discardableResult func center(to anchor: Anchor) -> PinLayout
     @discardableResult func center() -> PinLayout
 
-    @discardableResult func rightCenter(to point: CGPoint) -> PinLayout
     @discardableResult func rightCenter(to anchor: Anchor) -> PinLayout
     @discardableResult func rightCenter() -> PinLayout
 
-    @discardableResult func bottomLeft(to point: CGPoint) -> PinLayout
     @discardableResult func bottomLeft(to anchor: Anchor) -> PinLayout
     @discardableResult func bottomLeft() -> PinLayout
 
-    @discardableResult func bottomCenter(to point: CGPoint) -> PinLayout
     @discardableResult func bottomCenter(to anchor: Anchor) -> PinLayout
     @discardableResult func bottomCenter() -> PinLayout
 
-    @discardableResult func bottomRight(to point: CGPoint) -> PinLayout
     @discardableResult func bottomRight(to anchor: Anchor) -> PinLayout
     @discardableResult func bottomRight() -> PinLayout
 

--- a/PinLayoutSample/PinLayoutSample/UI/Tests/BothEdgesSnapped/BothEdgesSnappedView.swift
+++ b/PinLayoutSample/PinLayoutSample/UI/Tests/BothEdgesSnapped/BothEdgesSnappedView.swift
@@ -64,7 +64,6 @@ class BothEdgesSnappedView: UIView {
     var index = 0
     var anchorsList: [(String, Anchor)] = []
 
-
     init() {
         super.init(frame: .zero)
         
@@ -155,12 +154,16 @@ class BothEdgesSnappedView: UIView {
         bView.frame = CGRect(x: 160, y: 200, width: 110, height: 80)
         bViewChild.frame = CGRect(x: 40, y: 10, width: 60, height: 20)
 
-        let name = anchorsList[index].0
-        let anchor = anchorsList[index].1
-        print("aViewChild.pin.topCenter(to: bView.anchor.\(name))")
+//        let name = anchorsList[index].0
+//        let anchor = anchorsList[index].1
+//        print("aViewChild.pin.topCenter(to: bView.anchor.\(name))")
+//        aViewChild.pin.topCenter(to: anchor)
+//        printViewFrame(aViewChild, name: "aViewChild")
 
-        aViewChild.pin.topCenter(to: anchor)
-        printViewFrame(aViewChild, name: "aViewChild")
+//        aView.pin.left(0).right(0).top(0).bottom(0).margin(10)
+//        expect(aView.frame).to(equal(CGRect(x: 10.0, y: 10.0, width: 380.0, height: 380.0)))
+
+        aView.pin.topLeft(to: .zero).bottomRight(to: .zero).margin(10)
 
 //         topLeft
 //        aViewChild.pin.topLeft(to: bView.anchor.topLeft)
@@ -653,7 +656,7 @@ class BothEdgesSnappedView: UIView {
 //        bView.pin.bottomRight(of: aViewChild)
 //        bViewChild.pin.bottomRight(of: aViewChild) 
 
-//        printViewFrame(aView, name: "aView")
+        printViewFrame(aView, name: "aView")
 //        printViewFrame(aViewChild, name: "aViewChild")
 //        
 //        printViewFrame(bView, name: "bView")

--- a/PinLayoutTests/AdjustSizeSpec.swift
+++ b/PinLayoutTests/AdjustSizeSpec.swift
@@ -235,9 +235,9 @@ class AdjustSizeSpec: QuickSpec {
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 16.0, height: 100.0)))
             }
             
-            it("should warn that sizeThatFits(size:) won't be applied") {
-                aView.pin.top(0).bottom(70).width(100).sizeToFit()
-                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 0.0, width: 100.0, height: 70.0)))
+            it("should ajust the size of aView by calling sizeThatFits") {
+                aView.pin.top(0).height(70).width(100).sizeToFit()
+                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 0.0, width: 100.0, height: 16.0)))
             }
 
             it("should ajust the size of aView by calling sizeThatFits(width: CGFloat) method") {

--- a/PinLayoutTests/MarginsAndInsetsSpec.swift
+++ b/PinLayoutTests/MarginsAndInsetsSpec.swift
@@ -146,108 +146,108 @@ class MarginsAndInsetsSpec: QuickSpec {
         describe("the result of left&right margins and left&right insets when the right coordinate and the width are specified") {
             it("should adjust the aView") {
                 aView.pin.right(140).width(100).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 30.0, y: 100.0, width: 100.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 100.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.right(140).width(100).inset(10)
-                expect(aView.frame).to(equal(CGRect(x: 50.0, y: 100.0, width: 80.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 170.0, y: 100.0, width: 80.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.right(140).width(100).insetLeft(10)
-                expect(aView.frame).to(equal(CGRect(x: 50.0, y: 100.0, width: 90.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 170.0, y: 100.0, width: 90.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.right(140).width(100).margin(10).inset(10)
-                expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 80.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 160.0, y: 100.0, width: 80.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.right(140).width(100).insetRight(10)
-                expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 90.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 160.0, y: 100.0, width: 90.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.right(140).width(100).insetLeft(10).insetRight(10)
-                expect(aView.frame).to(equal(CGRect(x: 50.0, y: 100.0, width: 80.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 170.0, y: 100.0, width: 80.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.right(140).width(100).insetHorizontal(10)
-                expect(aView.frame).to(equal(CGRect(x: 50.0, y: 100.0, width: 80.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 170.0, y: 100.0, width: 80.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.right(140).width(100).marginLeft(10)
-                expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 100.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 160.0, y: 100.0, width: 100.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.right(140).width(100).marginRight(10)
-                expect(aView.frame).to(equal(CGRect(x: 30.0, y: 100.0, width: 100.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 100.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.right(140).width(100).marginHorizontal(10)
-                expect(aView.frame).to(equal(CGRect(x: 30.0, y: 100.0, width: 100.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 100.0, height: 120.0)))
             }
         }
 
         describe("the result of left&right margins and left&right insets when the left and right coordinate are specified") {
             it("should adjust the aView") {
-                aView.pin.left(140).right(240).margin(10)
+                aView.pin.left(140).right(160).margin(10)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 80.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.left(140).right(240).inset(10)
+                aView.pin.left(140).right(160).inset(10)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 80.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.left(140).right(240).insetLeft(10)
+                aView.pin.left(140).right(160).insetLeft(10)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 90.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.left(140).right(240).insetRight(10)
+                aView.pin.left(140).right(160).insetRight(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.left(140).right(240).insetLeft(10).insetRight(10)
+                aView.pin.left(140).right(160).insetLeft(10).insetRight(10)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 80.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.left(140).right(240).insetHorizontal(10)
+                aView.pin.left(140).right(160).insetHorizontal(10)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 80.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.left(140).right(240).margin(10).inset(10)
+                aView.pin.left(140).right(160).margin(10).inset(10)
                 expect(aView.frame).to(equal(CGRect(x: 160.0, y: 100.0, width: 60.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.left(140).right(240).marginLeft(10)
+                aView.pin.left(140).right(160).marginLeft(10)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 90.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.left(140).right(240).marginRight(10)
+                aView.pin.left(140).right(160).marginRight(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.left(140).right(240).marginLeft(10).marginRight(10)
+                aView.pin.left(140).right(160).marginLeft(10).marginRight(10)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 80.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.left(140).right(240).marginHorizontal(10)
+                aView.pin.left(140).right(160).marginHorizontal(10)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 80.0, height: 120.0)))
             }
         }
@@ -343,109 +343,109 @@ class MarginsAndInsetsSpec: QuickSpec {
         
         describe("the result of top&bottom margins and top&bottom insets when the bottom coordinate and the height are specified") {
             it("should adjust the aView") {
-                aView.pin.bottom(140).height(100).margin(10)
+                aView.pin.bottom(260).height(100).margin(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 30.0, width: 200.0, height: 100.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.bottom(140).height(100).inset(10)
+                aView.pin.bottom(260).height(100).inset(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 50.0, width: 200.0, height: 80.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.bottom(140).height(100).insetTop(10)
+                aView.pin.bottom(260).height(100).insetTop(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 50.0, width: 200.0, height: 90.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.bottom(140).height(100).margin(10).inset(10)
+                aView.pin.bottom(260).height(100).margin(10).inset(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 40.0, width: 200.0, height: 80.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.bottom(140).height(100).insetBottom(10)
+                aView.pin.bottom(260).height(100).insetBottom(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 40.0, width: 200.0, height: 90.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.bottom(140).height(100).insetTop(10).insetBottom(10)
+                aView.pin.bottom(260).height(100).insetTop(10).insetBottom(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 50.0, width: 200.0, height: 80.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.bottom(140).height(100).insetVertical(10)
+                aView.pin.bottom(260).height(100).insetVertical(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 50.0, width: 200.0, height: 80.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.bottom(140).height(100).marginTop(10)
+                aView.pin.bottom(260).height(100).marginTop(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 40.0, width: 200.0, height: 100.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.bottom(140).height(100).marginBottom(10)
+                aView.pin.bottom(260).height(100).marginBottom(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 30.0, width: 200.0, height: 100.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.bottom(140).height(100).marginVertical(10)
+                aView.pin.bottom(260).height(100).marginVertical(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 30.0, width: 200.0, height: 100.0)))
             }
         }
         
         describe("the result of top&bottom margins and top&bottom insets when the top and bottom coordinate are specified") {
             it("should adjust the aView") {
-                aView.pin.top(140).bottom(240).margin(10)
+                aView.pin.top(140).bottom(160).margin(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 150.0, width: 200.0, height: 80.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.top(140).bottom(240).inset(10)
+                aView.pin.top(140).bottom(160).inset(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 150.0, width: 200.0, height: 80.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.top(140).bottom(240).insetTop(10)
+                aView.pin.top(140).bottom(160).insetTop(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 150.0, width: 200.0, height: 90.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.top(140).bottom(240).insetBottom(10)
+                aView.pin.top(140).bottom(160).insetBottom(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 140.0, width: 200.0, height: 90.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.top(140).bottom(240).insetTop(10).insetBottom(10)
+                aView.pin.top(140).bottom(160).insetTop(10).insetBottom(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 150.0, width: 200.0, height: 80.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.top(140).bottom(240).insetVertical(10)
+                aView.pin.top(140).bottom(160).insetVertical(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 150.0, width: 200.0, height: 80.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.top(140).bottom(240).margin(10).inset(10)
+                aView.pin.top(140).bottom(160).margin(10).inset(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 160.0, width: 200.0, height: 60.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.top(140).bottom(240).marginTop(10)
+                aView.pin.top(140).bottom(160).marginTop(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 150.0, width: 200.0, height: 90.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.top(140).bottom(240).marginBottom(10)
+                aView.pin.top(140).bottom(160).marginBottom(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 140.0, width: 200.0, height: 90.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.top(140).bottom(240).marginTop(10).marginBottom(10)
+                aView.pin.top(140).bottom(160).marginTop(10).marginBottom(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 150.0, width: 200.0, height: 80.0)))
             }
             
             it("should adjust the aView") {
-                aView.pin.top(140).bottom(240).marginVertical(10)
+                aView.pin.top(140).bottom(160).marginVertical(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 150.0, width: 200.0, height: 80.0)))
             }
         }

--- a/PinLayoutTests/PinPointCoordinatesSpec.swift
+++ b/PinLayoutTests/PinPointCoordinatesSpec.swift
@@ -117,10 +117,10 @@ class PinPointCoordinatesSpec: QuickSpec {
         //
         describe("the result of the topLeft() and topLeft(to: UIView) methods") {
             it("should position the aView's topLeft corner at the specified position") {
-                aView.pin.topLeft(to: CGPoint(x: 25, y: 25))
+                aView.pin.top(25).left(25)
                 expect(aView.frame).to(equal(CGRect(x: 25.0, y: 25.0, width: 100.0, height: 60.0)))
             }
-            
+
             it("should position the aView's topLeft corner on its parent's topLeft corner") {
                 aView.pin.topLeft()
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 0.0, width: 100.0, height: 60.0)))
@@ -183,12 +183,11 @@ class PinPointCoordinatesSpec: QuickSpec {
         // topCenter
         //
         describe("the result of the topCenter() and topCenter(to: UIView) methods") {
-            
             it("should position the aView's topCenter corner at the specified position") {
-                aView.pin.topCenter(to: CGPoint(x: 100, y: 100))
+                aView.pin.top(100).hCenter(100)
                 expect(aView.frame).to(equal(CGRect(x: 50.0, y: 100.0, width: 100.0, height: 60.0)))
             }
-            
+
             it("should position the aView's topCenter corner on its parent's topCenter corner") {
                 aView.pin.topCenter()
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 0.0, width: 100.0, height: 60.0)))
@@ -252,8 +251,8 @@ class PinPointCoordinatesSpec: QuickSpec {
         //
         describe("the result of the topRight() and topRight(to: UIView) methods") {
             it("should position the aView's topRight corner at the specified position") {
-                aView.pin.topRight(to: CGPoint(x: 100, y: 100))
-                expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 100.0, height: 60.0)))
+                aView.pin.top(100).right(100)
+                expect(aView.frame).to(equal(CGRect(x: 200.0, y: 100.0, width: 100.0, height: 60.0)))
             }
 
             it("should position the aView's topRight corner at the specified position") {
@@ -314,7 +313,7 @@ class PinPointCoordinatesSpec: QuickSpec {
         //
         describe("the result of the leftCenter() and leftCenter(to: UIView) methods") {
             it("should position the aView's leftCenter corner at the specified position") {
-                aView.pin.leftCenter(to: CGPoint(x: 100, y: 100))
+                aView.pin.left(100).vCenter(100)
                 expect(aView.frame).to(equal(CGRect(x: 100, y: 70.0, width: 100.0, height: 60.0)))
             }
 
@@ -381,7 +380,7 @@ class PinPointCoordinatesSpec: QuickSpec {
         //
         describe("the result of the center() and center(to: UIView) methods") {
             it("should position the aView's center corner at the specified position") {
-                aView.pin.center(to: CGPoint(x: 100, y: 100))
+                aView.pin.hCenter(100).vCenter(100)
                 expect(aView.frame).to(equal(CGRect(x: 50.0, y: 70.0, width: 100.0, height: 60.0)))
             }
 
@@ -438,8 +437,8 @@ class PinPointCoordinatesSpec: QuickSpec {
         //
         describe("the result of the rightCenter() and rightCenter(to: UIView) methods") {
             it("should position the aView's rightCenter corner at the specified position") {
-                aView.pin.rightCenter(to: CGPoint(x: 100, y: 100))
-                expect(aView.frame).to(equal(CGRect(x: 0.0, y: 70.0, width: 100.0, height: 60.0)))
+                aView.pin.right(100).vCenter(100)
+                expect(aView.frame).to(equal(CGRect(x: 200.0, y: 70.0, width: 100.0, height: 60.0)))
             }
 
             it("should position the aView's rightCenter corner at the specified position") {
@@ -495,8 +494,8 @@ class PinPointCoordinatesSpec: QuickSpec {
         //
         describe("the result of the bottomLeft() and bottomLeft(to: UIView) methods") {
             it("should position the aView's bottomLeft corner at the specified position") {
-                aView.pin.bottomLeft(to: CGPoint(x: 100, y: 100))
-                expect(aView.frame).to(equal(CGRect(x: 100.0, y: 40.0, width: 100.0, height: 60.0)))
+                aView.pin.bottom(100).left(100)
+                expect(aView.frame).to(equal(CGRect(x: 100.0, y: 240.0, width: 100.0, height: 60.0)))
             }
 
             it("should position the aView's bottomLeft corner at the specified position") {
@@ -552,8 +551,8 @@ class PinPointCoordinatesSpec: QuickSpec {
         //
         describe("the result of the bottomCenter() and bottomCenter(to: UIView) methods") {
             it("should position the aView's bottomCenter corner at the specified position") {
-                aView.pin.bottomCenter(to: CGPoint(x: 100, y: 100))
-                expect(aView.frame).to(equal(CGRect(x: 50.0, y: 40.0, width: 100.0, height: 60.0)))
+                aView.pin.bottom(100).hCenter(100)
+                expect(aView.frame).to(equal(CGRect(x: 50.0, y: 240.0, width: 100.0, height: 60.0)))
             }
 
             it("should position the aView's bottomCenter corner at the specified position") {
@@ -609,8 +608,8 @@ class PinPointCoordinatesSpec: QuickSpec {
         //
         describe("the result of the bottomRight() and bottomRight(to: UIView) methods") {
             it("should position the aView's bottomRight corner at the specified position") {
-                aView.pin.bottomRight(to: CGPoint(x: 100, y: 100))
-                expect(aView.frame).to(equal(CGRect(x: 0.0, y: 40.0, width: 100.0, height: 60.0)))
+                aView.pin.bottom(100).right(100)
+                expect(aView.frame).to(equal(CGRect(x: 200.0, y: 240.0, width: 100.0, height: 60.0)))
             }
 
             it("should position the aView's bottomRight corner at the specified position") {


### PR DESCRIPTION
* PinLayout.right(CGFloat) and PinLayout.bottom(CGFloat) now specify the number of pixels from the superview right and bottom edges.

* Removed topLeft(:CGPoint), topRight(:CGPoint).  Explanation:
   1 -Usage to top(CGFloat), bottom(CGFloat), left(CGFloat), right(CGFLoat) should be used instead. It makes more sense since now right and bottom are related to the superview right and bottom edge.
   2- It was weird to specify a CGPoint.x coordinate that are normally specify the distance from the origin, but now it would have meant a distance from the superview right edge.

* Implement PinLayout.vCenter(CGFloat) and PinLayout.hCenter(CGFloat)