### PR TITLE
Fix an issue with `pin.vCenter()` and `pin.hCenter()`

### DIFF
--- a/PinLayout.podspec
+++ b/PinLayout.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "PinLayout"
-  s.version      = "1.0.6"
+  s.version      = "1.0.7"
   s.summary      = "Swift manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable."
 
   # This description is used to generate tags and improve search results.

--- a/PinLayout/PinLayoutImpl.swift
+++ b/PinLayout/PinLayoutImpl.swift
@@ -157,7 +157,8 @@ class PinLayoutImpl: PinLayout {
     @discardableResult
     func hCenter() -> PinLayout {
         func context() -> String { return "hCenter()" }
-        setHorizontalCenter(0, context)
+        guard let layoutSuperview = layoutSuperview(context) else { return self }
+        setHorizontalCenter(layoutSuperview.frame.width / 2, context)
         return self
     }
 
@@ -179,7 +180,8 @@ class PinLayoutImpl: PinLayout {
     @discardableResult
     func vCenter() -> PinLayout {
         func context() -> String { return "vCenter()" }
-        setVerticalCenter(0, context)
+        guard let layoutSuperview = layoutSuperview(context) else { return self }
+        setVerticalCenter(layoutSuperview.frame.height / 2, context)
         return self
     }
     

--- a/README.md
+++ b/README.md
@@ -193,17 +193,17 @@ PinLayout also has shorter version that pins a view’s edge **directly** on its
 **Methods**:
 
 * `top()`  
-Position the view top edge directly on its superview top edge. Similar to calling top(0)
+Position the view top edge directly on its superview top edge. Similar to calling `top(0)`.
 * `left()`  
-Position the view left edge directly on its superview top edge. Similar to calling left(0)
+Position the view left edge directly on its superview top edge. Similar to calling `left(0)`.
 * `bottom()`  
-Position the view bottom edge directly on its superview top edge. Similar to calling bottom(0)
+Position the view bottom edge directly on its superview top edge. Similar to calling `bottom(0)`.
 * `right()`  
-Position the view right edge directly on its superview top edge. Similar to calling right(0)
+Position the view right edge directly on its superview top edge. Similar to calling `right(0)`.
 * `hCenter()`  
-Position the view horizontal center directly on its superview horizontal center. Similar to calling hCenter(0).
+Position the view horizontal center directly on its superview horizontal center. Similar to calling `hCenter(superview.frame.width / 2)`.
 * `vCenter()`  
-Position the view vertical center directly on its superview vertical center. Similar to calling vCenter(0).
+Position the view vertical center directly on its superview vertical center. Similar to calling `hCenter(superview.frame.height / 2)`.
 
 ###### Usage examples:
 ```javascript
@@ -777,6 +777,10 @@ Cell D:
 ```
 
 <br>
+
+## Coming soon <a name="coming_soon"></a>
+* minWidth/maxWidth, minHeight/maxHeight
+* 
 
 
 ## FAQ <a name="faq"></a>

--- a/README.md
+++ b/README.md
@@ -780,7 +780,8 @@ Cell D:
 
 ## Coming soon <a name="coming_soon"></a>
 * minWidth/maxWidth, minHeight/maxHeight
-* 
+* CALayer support
+* ...
 
 
 ## FAQ <a name="faq"></a>


### PR DESCRIPTION
* Fix an issue with `pin.vCenter()` and `pin.hCenter()`These method were wrongly positioning views centered at position 0.
* Update documentation related to these methods.

Unit tests will be added later today.