### PR TITLE
Update relative methods signatures when specifying multiple relative views

### DIFF
--- a/Example/PinLayoutSample/UI/Tests/Intro/IntroView.swift
+++ b/Example/PinLayoutSample/UI/Tests/Intro/IntroView.swift
@@ -68,6 +68,6 @@ class IntroView: BaseView {
         logo.pin.topLeft().size(100).margin(topLayoutGuide + 10, 10, 10)
         segmented.pin.right(of: logo, aligned: .top).right().marginHorizontal(10)
         textLabel.pin.below(of: segmented, aligned: .left).width(of: segmented).pinEdges().marginTop(10).sizeToFit()
-        separatorView.pin.below(of: logo, textLabel, aligned: .left).right(to: segmented.edge.right).marginTop(10)
+        separatorView.pin.below(of: [logo, textLabel], aligned: .left).right(to: segmented.edge.right).marginTop(10)
     }
 }

--- a/Example/PinLayoutSample/UI/Tests/TableViewExample/Cells/MethodCell.swift
+++ b/Example/PinLayoutSample/UI/Tests/TableViewExample/Cells/MethodCell.swift
@@ -48,7 +48,7 @@ class MethodCell: UITableViewCell {
         
         iconImageView.pin.topLeft().size(30).margin(margin)
         nameLabel.pin.right(of: iconImageView, aligned: .center).right().marginHorizontal(margin).sizeToFit()
-        descriptionLabel.pin.below(of: iconImageView, nameLabel).left().right().margin(margin).sizeToFit()
+        descriptionLabel.pin.below(of: [iconImageView, nameLabel]).left().right().margin(margin).sizeToFit()
         
         return CGSize(width: frame.width, height: descriptionLabel.frame.maxY + margin)
     }

--- a/PinLayout.xcodeproj/project.pbxproj
+++ b/PinLayout.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		242E8DC31EED5AB2005935FB /* RelativePositionMultipleViewsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 242E8DC11EED5982005935FB /* RelativePositionMultipleViewsSpec.swift */; };
 		244C6E151E776A0C0074FC74 /* MarginsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244C6E141E776A0C0074FC74 /* MarginsSpec.swift */; };
 		244DF3031EF46F6C0090508B /* InfoTVOS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 244DF3011EF46F670090508B /* InfoTVOS.plist */; };
-		244DF3061EF46FC20090508B /* PinLayoutTVOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 244DF3041EF46FB90090508B /* PinLayoutTVOS.h */; };
+		244DF3061EF46FC20090508B /* PinLayoutTVOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 244DF3041EF46FB90090508B /* PinLayoutTVOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		245302071ED05FD000E13F29 /* AccurencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 245302061ED05FD000E13F29 /* AccurencyTests.swift */; };
 		2469C4FC1E74855D00073BEE /* PinEdgeCoordinateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2469C4FB1E74855D00073BEE /* PinEdgeCoordinateSpec.swift */; };
 		2469C5001E75D74000073BEE /* AdjustSizeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2469C4FF1E75D74000073BEE /* AdjustSizeSpec.swift */; };
@@ -22,6 +22,10 @@
 		2469C5041E75DB7600073BEE /* RectNimbleMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2469C5031E75DB7600073BEE /* RectNimbleMatcher.swift */; };
 		246D36481E6C46F50050F202 /* PinPointCoordinatesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246D36471E6C46F50050F202 /* PinPointCoordinatesSpec.swift */; };
 		2482908C1E78CFFC00667D08 /* RelativePositionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2482908B1E78CFFC00667D08 /* RelativePositionSpec.swift */; };
+		24949A281EF550E2003643D3 /* PinLayoutImpl+Relative.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24949A271EF550E2003643D3 /* PinLayoutImpl+Relative.swift */; };
+		24949A2A1EF551D6003643D3 /* PinLayoutImpl+Coordinates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24949A291EF551D6003643D3 /* PinLayoutImpl+Coordinates.swift */; };
+		24949A2C1EF55216003643D3 /* PinLayoutImpl+Warning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24949A2B1EF55216003643D3 /* PinLayoutImpl+Warning.swift */; };
+		24949A2E1EF69474003643D3 /* PinLayout+Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24949A2D1EF69474003643D3 /* PinLayout+Filters.swift */; };
 		249EFE841E64FB4C00165E39 /* PinLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 249EFE7A1E64FB4C00165E39 /* PinLayout.framework */; };
 		249EFE891E64FB4C00165E39 /* PinLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249EFE881E64FB4C00165E39 /* PinLayoutTests.swift */; };
 		24A9782E1EE845BB002BD0F1 /* Coordinates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A9782D1EE845BB002BD0F1 /* Coordinates.swift */; };
@@ -72,6 +76,10 @@
 		2469C5031E75DB7600073BEE /* RectNimbleMatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RectNimbleMatcher.swift; sourceTree = "<group>"; };
 		246D36471E6C46F50050F202 /* PinPointCoordinatesSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinPointCoordinatesSpec.swift; sourceTree = "<group>"; };
 		2482908B1E78CFFC00667D08 /* RelativePositionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelativePositionSpec.swift; sourceTree = "<group>"; };
+		24949A271EF550E2003643D3 /* PinLayoutImpl+Relative.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PinLayoutImpl+Relative.swift"; sourceTree = "<group>"; };
+		24949A291EF551D6003643D3 /* PinLayoutImpl+Coordinates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PinLayoutImpl+Coordinates.swift"; sourceTree = "<group>"; };
+		24949A2B1EF55216003643D3 /* PinLayoutImpl+Warning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PinLayoutImpl+Warning.swift"; sourceTree = "<group>"; };
+		24949A2D1EF69474003643D3 /* PinLayout+Filters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PinLayout+Filters.swift"; sourceTree = "<group>"; };
 		249EFE7A1E64FB4C00165E39 /* PinLayout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PinLayout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		249EFE831E64FB4C00165E39 /* PinLayoutTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PinLayoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		249EFE881E64FB4C00165E39 /* PinLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinLayoutTests.swift; sourceTree = "<group>"; };
@@ -146,6 +154,7 @@
 			isa = PBXGroup;
 			children = (
 				DFC97CA61E8A8F2C001545D5 /* PinLayout.swift */,
+				24949A2D1EF69474003643D3 /* PinLayout+Filters.swift */,
 				DFA06B031E8B38B300B6D5E7 /* Impl */,
 				DF11A3741E834181008B33E5 /* Supporting Files */,
 			);
@@ -188,6 +197,9 @@
 			children = (
 				24A9782D1EE845BB002BD0F1 /* Coordinates.swift */,
 				DFC97CA41E8A8EB3001545D5 /* PinLayoutImpl.swift */,
+				24949A291EF551D6003643D3 /* PinLayoutImpl+Coordinates.swift */,
+				24949A271EF550E2003643D3 /* PinLayoutImpl+Relative.swift */,
+				24949A2B1EF55216003643D3 /* PinLayoutImpl+Warning.swift */,
 				DF11A3701E833F03008B33E5 /* TypesImpl.swift */,
 			);
 			name = Impl;
@@ -241,7 +253,6 @@
 				249EFE761E64FB4C00165E39 /* Frameworks */,
 				249EFE771E64FB4C00165E39 /* Headers */,
 				249EFE781E64FB4C00165E39 /* Resources */,
-				9045643059E57F984AB8FF52 /* Tailor */,
 			);
 			buildRules = (
 			);
@@ -344,23 +355,6 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		9045643059E57F984AB8FF52 /* Tailor */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Tailor;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#if hash tailor 2>/dev/null; then\n#tailor\n#else\n#  echo \"warning: Please install Tailor from https://tailor.sh\"\n#fi";
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
 		244DF2F31EF46C500090508B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -374,9 +368,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				DF11A3711E833F03008B33E5 /* TypesImpl.swift in Sources */,
+				24949A2C1EF55216003643D3 /* PinLayoutImpl+Warning.swift in Sources */,
 				DFC97CA71E8A8F2C001545D5 /* PinLayout.swift in Sources */,
+				24949A2E1EF69474003643D3 /* PinLayout+Filters.swift in Sources */,
 				DFC97CA51E8A8EB3001545D5 /* PinLayoutImpl.swift in Sources */,
 				24A9782E1EE845BB002BD0F1 /* Coordinates.swift in Sources */,
+				24949A281EF550E2003643D3 /* PinLayoutImpl+Relative.swift in Sources */,
+				24949A2A1EF551D6003643D3 /* PinLayoutImpl+Coordinates.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -572,7 +570,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mirego.PinLayout;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -594,7 +591,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mirego.PinLayout;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/README.md
+++ b/README.md
@@ -399,16 +399,23 @@ PinLayout also has methods to position relative to other views. The view can be 
 
 **Methods:**
 
-* `above(of relativeViews: UIView...)`  
-Position the view above the specified views. One or many relative views can be specied. This method is similar to pinning the view’s bottom edge.
-* `below(of relativeViews: UIView...)`  
-Position the view below the specified view. One or many relative views can be specied. This method is similar to pinning the view’s top edge.
-* `left(of relativeViews: UIView...)`  
-Position the view left of the specified view. One or many relative views can be specied. This method is similar to pinning the view’s right edge.
-* `right(of relativeViews: UIView...)`  
-Position the view right of the specified view. One or many relative views can be specied. This method is similar to pinning the view’s left edge.
+* `above(of: UIView)`  
+`above(of: [UIView])`  
+Position the view above the specified view(s). One or many relative views can be specied. This method is similar to pinning the view’s bottom edge.  
+  
+* `below(of: UIView)`  
+`below(of: [UIView])`  
+Position the view below the specified view(s). One or many relative views can be specied. This method is similar to pinning the view’s top edge.  
+  
+* `left(of: UIView)`  
+`left(of: [UIView])`  
+Position the view left of the specified view(s). One or many relative views can be specied. This method is similar to pinning the view’s right edge.  
+  
+* `right(of: UIView)`  
+`right(of: [UIView])`  
+Position the view right of the specified view(s). One or many relative views can be specied. This method is similar to pinning the view’s left edge.
 
-:pushpin: **Multiple relative views**: If for example a call to `below(of ...) specify multiple relative views, the view will be layouted below *ALL* these views. 
+:pushpin: **Multiple relative views**: If for example a call to `below(of: [...]) specify multiple relative views, the view will be layouted below *ALL* these views. 
 
 :pushpin: These methods **set the position of a view's edge**: top, left, bottom or right. For example `below(of ...)` set the view's top edge, `right(of ...) set the view's left edge, ...
 
@@ -417,7 +424,7 @@ Position the view right of the specified view. One or many relative views can be
 ###### Usage examples:
 ```swift
 	view.pin.left(of: view2)
-	view.pin.below(of: view2, view3, view4)
+	view.pin.below(of: [view2, view3, view4])
 	view.pin.left(of: view1).above(of: view2).below(of: view3).right(of: view4)
 ```
 
@@ -451,14 +458,21 @@ PinLayout also has methods to position relative to other views but with also the
 
 **Methods:**
 
-* `above(of relativeViews: UIView..., aligned: HorizontalAlignment)`  
-Position the view above the specified views and aligned it using the specified HorizontalAlignment. One or many relative views can be specied. This method is similar to pinning one view’s anchor: bottomLeft, bottomCenter or bottomRight.
-* `below(of relativeViews: UIView..., aligned: HorizontalAlignment)`  
-Position the view below the specified view and aligned it using the specified HorizontalAlignment. One or many relative views can be specied. This method is similar to pinning one view’s anchor: topLeft, topCenter or topRight.
-* `left(of relativeViews: UIView..., aligned: VerticalAlignment)`  
-Position the view left of the specified view and aligned it using the specified VerticalAlignment. One or many relative views can be specied. This method is similar to pinning one view’s anchor: topRight, rightCenter or bottomRight.
-* `right(of relativeViews: UIView..., aligned: VerticalAlignment)`  
-Position the view right of the specified view and aligned it using the specified VerticalAlignment. One or many relative views can be specied. This method is similar to pinning one view’s anchor: topLeft, leftCenter or bottomLeft.
+* `above(of: UIView, aligned: HorizontalAlignment)`  
+`above(of: [UIView], aligned: HorizontalAlignment)`  
+Position the view above the specified view(s) and aligned it using the specified HorizontalAlignment. One or many relative views can be specied. This method is similar to pinning one view’s anchor: bottomLeft, bottomCenter or bottomRight.  
+  
+* `below(of: UIView, aligned: HorizontalAlignment)`  
+`below(of: [UIView], aligned: HorizontalAlignment)`  
+Position the view below the specified view(s) and aligned it using the specified HorizontalAlignment. One or many relative views can be specied. This method is similar to pinning one view’s anchor: topLeft, topCenter or topRight.  
+  
+* `left(of: UIView, aligned: VerticalAlignment)`  
+`left(of: [UIView], aligned: HorizontalAlignment)`  
+Position the view left of the specified view(s) and aligned it using the specified VerticalAlignment. One or many relative views can be specied. This method is similar to pinning one view’s anchor: topRight, rightCenter or bottomRight.  
+  
+* `right(of: UIView, aligned: VerticalAlignment)`  
+`right(of: [UIView], aligned: HorizontalAlignment)`  
+Position the view right of the specified view(s) and aligned it using the specified VerticalAlignment. One or many relative views can be specied. This method is similar to pinning one view’s anchor: topLeft, leftCenter or bottomLeft.
 
 **How alignment is applied:**
 
@@ -469,7 +483,7 @@ Position the view right of the specified view and aligned it using the specified
 *  `VerticalAlignment.center`: The view's vCenter edge will be aligned with the average vCenter of all  relative views.
 *  `VerticalAlignment.bottom`: The view's bottom edge will be aligned to the bottom most relative view.
 
-:pushpin: **Multiple relative views**: If for example a call to `below(of:, aligned:) specify multiple relative views, the view will be layouted below *ALL* these views. The alignment will be applied using all relative view
+:pushpin: **Multiple relative views**: If for example a call to `below(of: [...], aligned:) specify multiple relative views, the view will be layouted below *ALL* these views. The alignment will be applied using all relative view
 
 :pushpin: These methods **set the position of a view's anchor**: topLeft, topCenter, topRight, leftCenter, .... For example `below(of ..., aligned: .right)` set the view's topRight anchor, `right(of ..., aligned: .center) set the view's centerLeft anchor, ...
 
@@ -479,7 +493,7 @@ Position the view right of the specified view and aligned it using the specified
 ###### Usage examples:
 ```swift
 	view.pin.above(of: view2, aligned: .left)
-	view.pin.below(of: view2, view3, view4, aligned: .left)
+	view.pin.below(of: [view2, view3, view4], aligned: .left)
 	view.pin.left(of: view2, aligned: .top).right(of: view3, aligned: .bottom)
 ```
 
@@ -504,7 +518,7 @@ View A should be left aligned to the UIImageView and right aligned to the UILabe
 ![](docs/pinlayout-relative-multi.png)
 
 ```swift
-	a.pin.below(of: imageView, label, aligned: .left).right(to: label.edge.right).marginTop(10)
+	a.pin.below(of: [imageView, label], aligned: .left).right(to: label.edge.right).marginTop(10)
 ```
 This is an equivalent solutions using other methods:
 

--- a/Sources/PinLayout+Filters.swift
+++ b/Sources/PinLayout+Filters.swift
@@ -1,0 +1,16 @@
+//
+//  PinLayout+Filters.swift
+//  PinLayout
+//
+//  Created by DION, Luc (MTL) on 2017-06-18.
+//  Copyright © 2017 mcswiftlayyout.mirego.com. All rights reserved.
+//
+#if os(iOS) || os(tvOS)
+import UIKit
+
+// Filter out all hidden views (isHidden is true or alpha is 0)
+public func visibles(_ views: [UIView]) -> [UIView] {
+    return views.filter({ !$0.isHidden && $0.alpha > 0 })
+}
+
+#endif

--- a/Sources/PinLayout.swift
+++ b/Sources/PinLayout.swift
@@ -182,14 +182,25 @@ public protocol PinLayout {
     //
     // Layout using relative positioning
     //
-    @discardableResult func above(of relativeViews: UIView...) -> PinLayout
-    @discardableResult func above(of relativeViews: UIView..., aligned: HorizontalAlignment) -> PinLayout
-    @discardableResult func below(of relativeViews: UIView...) -> PinLayout
-    @discardableResult func below(of relativeViews: UIView..., aligned: HorizontalAlignment) -> PinLayout
-    @discardableResult func left(of relativeViews: UIView...) -> PinLayout
-    @discardableResult func left(of relativeViews: UIView..., aligned: VerticalAlignment) -> PinLayout
-    @discardableResult func right(of relativeViews: UIView...) -> PinLayout
-    @discardableResult func right(of relativeViews: UIView..., aligned: VerticalAlignment) -> PinLayout
+    @discardableResult func above(of: UIView) -> PinLayout
+    @discardableResult func above(of: [UIView]) -> PinLayout
+    @discardableResult func above(of: UIView, aligned: HorizontalAlignment) -> PinLayout
+    @discardableResult func above(of: [UIView], aligned: HorizontalAlignment) -> PinLayout
+    
+    @discardableResult func below(of: UIView) -> PinLayout
+    @discardableResult func below(of: [UIView]) -> PinLayout
+    @discardableResult func below(of: UIView, aligned: HorizontalAlignment) -> PinLayout
+    @discardableResult func below(of: [UIView], aligned: HorizontalAlignment) -> PinLayout
+    
+    @discardableResult func left(of: UIView) -> PinLayout
+    @discardableResult func left(of: [UIView]) -> PinLayout
+    @discardableResult func left(of: UIView, aligned: VerticalAlignment) -> PinLayout
+    @discardableResult func left(of: [UIView], aligned: VerticalAlignment) -> PinLayout
+    
+    @discardableResult func right(of: UIView) -> PinLayout
+    @discardableResult func right(of: [UIView]) -> PinLayout
+    @discardableResult func right(of: UIView, aligned: VerticalAlignment) -> PinLayout
+    @discardableResult func right(of: [UIView], aligned: VerticalAlignment) -> PinLayout
 
     //
     // Width, height and size

--- a/Sources/PinLayoutImpl+Coordinates.swift
+++ b/Sources/PinLayoutImpl+Coordinates.swift
@@ -1,0 +1,228 @@
+//
+//  PinLayoutImpl+Coordinates.swift
+//  PinLayout
+//
+//  Created by DION, Luc (MTL) on 2017-06-17.
+//  Copyright © 2017 mcswiftlayyout.mirego.com. All rights reserved.
+//
+#if os(iOS) || os(tvOS)
+import UIKit
+
+extension PinLayoutImpl {
+    internal func setTop(_ value: CGFloat, _ context: Context) {
+        if let _bottom = _bottom, let height = height {
+            warnConflict(context, ["bottom": _bottom, "height": height])
+        } else if let _vCenter = _vCenter {
+            warnConflict(context, ["Vertical Center": _vCenter])
+        } else if let _top = _top, _top != value {
+            warnPropertyAlreadySet("top", propertyValue: _top, context)
+        } else {
+            _top = value
+        }
+    }
+    
+    internal func setLeft(_ value: CGFloat, _ context: Context) {
+        if let _right = _right, let width = width  {
+            warnConflict(context, ["right": _right, "width": width])
+        } else if let _hCenter = _hCenter {
+            warnConflict(context, ["Horizontal Center": _hCenter])
+        } else if let _left = _left, _left != value {
+            warnPropertyAlreadySet("left", propertyValue: _left, context)
+        } else {
+            _left = value
+        }
+    }
+    
+    internal func setRight(_ value: CGFloat, _ context: Context) {
+        if let _left = _left, let width = width  {
+            warnConflict(context, ["left": _left, "width": width])
+        } else if let _hCenter = _hCenter {
+            warnConflict(context, ["Horizontal Center": _hCenter])
+        } else if let _right = _right, _right != value {
+            warnPropertyAlreadySet("right", propertyValue: _right, context)
+        } else {
+            _right = value
+        }
+    }
+    
+    internal func setBottom(_ value: CGFloat, _ context: Context) {
+        if let _top = _top, let height = height {
+            warnConflict(context, ["top": _top, "height": height])
+        } else if let _vCenter = _vCenter {
+            warnConflict(context, ["Vertical Center": _vCenter])
+        } else if let _bottom = _bottom, _bottom != value {
+            warnPropertyAlreadySet("bottom", propertyValue: _bottom, context)
+        } else {
+            _bottom = value
+        }
+    }
+    
+    internal func setHorizontalCenter(_ value: CGFloat, _ context: Context) {
+        if let _left = _left {
+            warnConflict(context, ["left": _left])
+        } else if let _right = _right {
+            warnConflict(context, ["right": _right])
+        } else if let _hCenter = _hCenter, _hCenter != value {
+            warnPropertyAlreadySet("Horizontal Center", propertyValue: _hCenter, context)
+        } else {
+            _hCenter = value
+        }
+    }
+    
+    internal func setVerticalCenter(_ value: CGFloat, _ context: Context) {
+        if let _top = _top {
+            warnConflict(context, ["top": _top])
+        } else if let _bottom = _bottom {
+            warnConflict(context, ["bottom": _bottom])
+        } else if let _vCenter = _vCenter, _vCenter != value {
+            warnPropertyAlreadySet("Vertical Center", propertyValue: _vCenter, context)
+        } else {
+            _vCenter = value
+        }
+    }
+    
+    @discardableResult
+    internal func setTopLeft(_ point: CGPoint, _ context: Context) -> PinLayout {
+        setLeft(point.x, context)
+        setTop(point.y, context)
+        return self
+    }
+    
+    @discardableResult
+    internal func setTopCenter(_ point: CGPoint, _ context: Context) -> PinLayout {
+        setHorizontalCenter(point.x, context)
+        setTop(point.y, context)
+        return self
+    }
+    
+    @discardableResult
+    internal func setTopRight(_ point: CGPoint, _ context: Context) -> PinLayout {
+        setRight(point.x, context)
+        setTop(point.y, context)
+        return self
+    }
+    
+    @discardableResult
+    internal func setLeftCenter(_ point: CGPoint, _ context: Context) -> PinLayout {
+        setLeft(point.x, context)
+        setVerticalCenter(point.y, context)
+        return self
+    }
+    
+    @discardableResult
+    internal func setCenter(_ point: CGPoint, _ context: Context) -> PinLayout {
+        setHorizontalCenter(point.x, context)
+        setVerticalCenter(point.y, context)
+        return self
+    }
+    
+    @discardableResult
+    internal func setRightCenter(_ point: CGPoint, _ context: Context) -> PinLayout {
+        setRight(point.x, context)
+        setVerticalCenter(point.y, context)
+        return self
+    }
+    
+    @discardableResult
+    internal func setBottomLeft(_ point: CGPoint, _ context: Context) -> PinLayout {
+        setLeft(point.x, context)
+        setBottom(point.y, context)
+        return self
+    }
+    
+    @discardableResult
+    internal func setBottomCenter(_ point: CGPoint, _ context: Context) -> PinLayout {
+        setHorizontalCenter(point.x, context)
+        setBottom(point.y, context)
+        return self
+    }
+    
+    @discardableResult
+    internal func setBottomRight(_ point: CGPoint, _ context: Context) -> PinLayout {
+        setRight(point.x, context)
+        setBottom(point.y, context)
+        return self
+    }
+    
+    @discardableResult
+    internal func setWidth(_ value: CGFloat, _ context: Context) -> PinLayout {
+        guard value >= 0 else {
+            warn("the width (\(value)) ust be greater than or equal to zero.", context); return self
+        }
+        
+        if let _left = _left, let _right = _right {
+            warnConflict(context, ["left": _left, "right": _right])
+        } else if let width = width, width != value {
+            warnPropertyAlreadySet("width", propertyValue: width, context)
+        } else {
+            width = value
+        }
+        return self
+    }
+    
+    @discardableResult
+    internal func setHeight(_ value: CGFloat, _ context: Context) -> PinLayout {
+        guard value >= 0 else {
+            warn("the height (\(value)) must be greater than or equal to zero.", context); return self
+        }
+        
+        if let _top = _top, let _bottom = _bottom {
+            warnConflict(context, ["top": _top, "bottom": _bottom])
+        } else if let height = height, height != value {
+            warnPropertyAlreadySet("height", propertyValue: height, context)
+        } else {
+            height = value
+        }
+        return self
+    }
+    
+    internal func setSize(_ size: CGSize, _ context: Context) -> PinLayout {
+        setWidth(size.width, { return "\(context())'s width" })
+        setHeight(size.height, { return "\(context())'s height" })
+        return self
+    }
+    
+    fileprivate func computeCoordinates(_ point: CGPoint, _ layoutSuperview: UIView, _ referenceView: UIView, _ referenceSuperview: UIView) -> CGPoint {
+        if layoutSuperview == referenceSuperview {
+            return point   // same superview => no coordinates conversion required.
+        } else {
+            return referenceSuperview.convert(point, to: layoutSuperview)
+        }
+    }
+    
+    internal  func computeCoordinates(forAnchors anchors: [Anchor], _ context: Context) -> [CGPoint]? {
+        guard let layoutSuperview = layoutSuperview(context) else { return nil }
+        var results: [CGPoint] = []
+        anchors.forEach({ (anchor) in
+            let anchor = anchor as! AnchorImpl
+            if let referenceSuperview = referenceSuperview(anchor.view, context) {
+                results.append(computeCoordinates(anchor.point, layoutSuperview, anchor.view, referenceSuperview))
+            }
+        })
+        
+        guard results.count > 0 else {
+            warn("no valid references", context)
+            return nil
+        }
+        
+        return results
+    }
+    
+    internal func computeCoordinate(forEdge edge: HorizontalEdge, _ context: Context) -> CGFloat? {
+        let edge = edge as! HorizontalEdgeImpl
+        guard let layoutSuperview = layoutSuperview(context) else { return nil }
+        guard let referenceSuperview = referenceSuperview(edge.view, context) else { return nil }
+        
+        return computeCoordinates(CGPoint(x: edge.x, y: 0), layoutSuperview, edge.view, referenceSuperview).x
+    }
+    
+    internal func computeCoordinate(forEdge edge: VerticalEdge, _ context: Context) -> CGFloat? {
+        let edge = edge as! VerticalEdgeImpl
+        guard let layoutSuperview = layoutSuperview(context) else { return nil }
+        guard let referenceSuperview = referenceSuperview(edge.view, context) else { return nil }
+        
+        return computeCoordinates(CGPoint(x: 0, y: edge.y), layoutSuperview, edge.view, referenceSuperview).y
+    }
+}
+
+#endif

--- a/Sources/PinLayoutImpl+Relative.swift
+++ b/Sources/PinLayoutImpl+Relative.swift
@@ -1,0 +1,300 @@
+//
+//  PinLayoutImpl+Relative.swift
+//  PinLayout
+//
+//  Created by DION, Luc (MTL) on 2017-06-17.
+//  Copyright © 2017 mcswiftlayyout.mirego.com. All rights reserved.
+//
+#if os(iOS) || os(tvOS)
+import UIKit
+    
+extension PinLayoutImpl {
+    
+    //
+    // above(of ...)
+    //
+    @discardableResult
+    func above(of relativeView: UIView) -> PinLayout {
+        func context() -> String { return "above(of: \(relativeView))" }
+        return above(relativeViews: [relativeView], aligned: nil, context: context)
+    }
+    
+    @discardableResult
+    func above(of relativeViews: [UIView]) -> PinLayout {
+        func context() -> String { return "above(of: \(relativeViews))" }
+        return above(relativeViews: relativeViews, aligned: nil, context: context)
+    }
+    
+    @discardableResult
+    func above(of relativeView: UIView, aligned: HorizontalAlignment) -> PinLayout {
+        func context() -> String { return "above(of: \(relativeView), aligned: \(aligned))" }
+        return above(relativeViews: [relativeView], aligned: aligned, context: context)
+    }
+    
+    func above(of relativeViews: [UIView], aligned: HorizontalAlignment) -> PinLayout {
+        func context() -> String { return "above(of: \(relativeViews), aligned: \(aligned))" }
+        return above(relativeViews: relativeViews, aligned: aligned, context: context)
+    }
+    
+    //
+    // below(of ...)
+    //
+    @discardableResult
+    func below(of relativeView: UIView) -> PinLayout {
+        func context() -> String { return "below(of: \(relativeView))" }
+        return below(relativeViews: [relativeView], aligned: nil, context: context)
+    }
+    
+    @discardableResult
+    func below(of relativeViews: [UIView]) -> PinLayout {
+        func context() -> String { return "below(of: \(relativeViews))" }
+        return below(relativeViews: relativeViews, aligned: nil, context: context)
+    }
+    
+    @discardableResult
+    func below(of relativeView: UIView, aligned: HorizontalAlignment) -> PinLayout {
+        func context() -> String { return "below(of: \(relativeView), aligned: \(aligned))" }
+        return below(relativeViews: [relativeView], aligned: aligned, context: context)
+    }
+    
+    @discardableResult
+    func below(of relativeViews: [UIView], aligned: HorizontalAlignment) -> PinLayout {
+        func context() -> String { return "below(of: \(relativeViews), aligned: \(aligned))" }
+        return below(relativeViews: relativeViews, aligned: aligned, context: context)
+    }
+    
+    @discardableResult
+    func below(ofVisible relativeViews: [UIView]) -> PinLayout {
+        func context() -> String { return "below(ofVisible: \(relativeViews))" }
+        return below(relativeViews: relativeViews, aligned: nil, context: context)
+    }
+    
+    @discardableResult
+    func below(ofVisible relativeViews: [UIView], aligned: HorizontalAlignment) -> PinLayout {
+        func context() -> String { return "below(ofVisible: \(relativeViews), aligned: \(aligned))" }
+        return below(relativeViews: relativeViews, aligned: aligned, context: context)
+    }
+    
+    //
+    // left(of ...)
+    //
+    @discardableResult
+    func left(of relativeView: UIView) -> PinLayout {
+        func context() -> String { return "left(of: \(relativeView))" }
+        return left(relativeViews: [relativeView], aligned: nil, context: context)
+    }
+    
+    @discardableResult
+    func left(of relativeViews: [UIView]) -> PinLayout {
+        func context() -> String { return "left(of: \(relativeViews))" }
+        return left(relativeViews: relativeViews, aligned: nil, context: context)
+    }
+    
+    @discardableResult
+    func left(of relativeView: UIView, aligned: VerticalAlignment) -> PinLayout {
+        func context() -> String { return "left(of: \(relativeView), aligned: \(aligned))" }
+        return left(relativeViews: [relativeView], aligned: aligned, context: context)
+    }
+    
+    @discardableResult
+    func left(of relativeViews: [UIView], aligned: VerticalAlignment) -> PinLayout {
+        func context() -> String { return "left(of: \(relativeViews), aligned: \(aligned))" }
+        return left(relativeViews: relativeViews, aligned: aligned, context: context)
+    }
+
+    //
+    // right(of ...)
+    //
+    @discardableResult
+    func right(of relativeView: UIView) -> PinLayout {
+        func context() -> String { return "right(of: \(relativeView))" }
+        return right(relativeViews: [relativeView], aligned: nil, context: context)
+    }
+    
+    @discardableResult
+    func right(of relativeViews: [UIView]) -> PinLayout {
+        func context() -> String { return "right(of: \(relativeViews))" }
+        return right(relativeViews: relativeViews, aligned: nil, context: context)
+    }
+
+    @discardableResult
+    func right(of relativeView: UIView, aligned: VerticalAlignment) -> PinLayout {
+        func context() -> String { return "right(of: \(relativeView), aligned: \(aligned))" }
+        return right(relativeViews: [relativeView], aligned: aligned, context: context)
+    }
+    
+    @discardableResult
+    func right(of relativeViews: [UIView], aligned: VerticalAlignment) -> PinLayout {
+        func context() -> String { return "right(of: \(relativeViews), aligned: \(aligned))" }
+        return right(relativeViews: relativeViews, aligned: aligned, context: context)
+    }
+}
+
+// MARK: fileprivate
+extension PinLayoutImpl {
+    @discardableResult
+    fileprivate func above(relativeViews: [UIView], aligned: HorizontalAlignment?, context: Context) -> PinLayout {
+        guard let relativeViews = validateRelativeViews(relativeViews, context: context) else { return self }
+        
+        let anchors: [Anchor]
+        if let aligned = aligned {
+            switch aligned {
+            case .left:    anchors = relativeViews.map({ $0.anchor.topLeft })
+            case .center: anchors = relativeViews.map({ $0.anchor.topCenter })
+            case .right:   anchors = relativeViews.map({ $0.anchor.topRight })
+            }
+        } else {
+            anchors = relativeViews.map({ $0.anchor.topLeft })
+        }
+        
+        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
+            setBottom(getTopMostCoordinate(list: coordinatesList), context)
+            applyHorizontalAlignment(aligned, coordinatesList: coordinatesList, context: context)
+        }
+        return self
+    }
+
+    @discardableResult
+    fileprivate func below(relativeViews: [UIView], aligned: HorizontalAlignment?, context: Context) -> PinLayout {
+        guard let relativeViews = validateRelativeViews(relativeViews, context: context) else { return self }
+        
+        let anchors: [Anchor]
+        if let aligned = aligned {
+            switch aligned {
+            case .left:    anchors = relativeViews.map({ $0.anchor.bottomLeft })
+            case .center: anchors = relativeViews.map({ $0.anchor.bottomCenter })
+            case .right:   anchors = relativeViews.map({ $0.anchor.bottomRight })
+            }
+        } else {
+            anchors = relativeViews.map({ $0.anchor.bottomLeft })
+        }
+        
+        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
+            setTop(getBottomMostCoordinate(list: coordinatesList), context)
+            applyHorizontalAlignment(aligned, coordinatesList: coordinatesList, context: context)
+        }
+        return self
+    }
+    
+    fileprivate func left(relativeViews: [UIView], aligned: VerticalAlignment?, context: Context) -> PinLayout {
+        guard let relativeViews = validateRelativeViews(relativeViews, context: context) else { return self }
+        
+        let anchors: [Anchor]
+        if let aligned = aligned {
+            switch aligned {
+            case .top:    anchors = relativeViews.map({ $0.anchor.topLeft })
+            case .center: anchors = relativeViews.map({ $0.anchor.leftCenter })
+            case .bottom: anchors = relativeViews.map({ $0.anchor.bottomLeft })
+            }
+        } else {
+            anchors = relativeViews.map({ $0.anchor.topLeft })
+        }
+        
+        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
+            setRight(getLeftMostCoordinate(list: coordinatesList), context)
+            applyVerticalAlignment(aligned, coordinatesList: coordinatesList, context: context)
+        }
+        return self
+    }
+    
+    fileprivate func right(relativeViews: [UIView], aligned: VerticalAlignment?, context: Context) -> PinLayout {
+        guard let relativeViews = validateRelativeViews(relativeViews, context: context) else { return self }
+        
+        let anchors: [Anchor]
+        if let aligned = aligned {
+            switch aligned {
+            case .top:    anchors = relativeViews.map({ $0.anchor.topRight })
+            case .center: anchors = relativeViews.map({ $0.anchor.rightCenter })
+            case .bottom: anchors = relativeViews.map({ $0.anchor.bottomRight })
+            }
+        } else {
+            anchors = relativeViews.map({ $0.anchor.topRight })
+        }
+        
+        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
+            setLeft(getRightMostCoordinate(list: coordinatesList), context)
+            applyVerticalAlignment(aligned, coordinatesList: coordinatesList, context: context)
+        }
+        return self
+    }
+    
+    fileprivate func applyHorizontalAlignment(_ aligned: HorizontalAlignment?, coordinatesList: [CGPoint], context: Context) {
+        if let aligned = aligned {
+            switch aligned {
+            case .left:   setLeft(getLeftMostCoordinate(list: coordinatesList), context)
+            case .center: setHorizontalCenter(getAverageHCenterCoordinate(list: coordinatesList), context)
+            case .right:  setRight(getRightMostCoordinate(list: coordinatesList), context)
+            }
+        }
+    }
+    
+    fileprivate func applyVerticalAlignment(_ aligned: VerticalAlignment?, coordinatesList: [CGPoint], context: Context) {
+        if let aligned = aligned {
+            switch aligned {
+            case .top:    setTop(getTopMostCoordinate(list: coordinatesList), context)
+            case .center: setVerticalCenter(getAverageVCenterCoordinate(list: coordinatesList), context)
+            case .bottom: setBottom(getBottomMostCoordinate(list: coordinatesList), context)
+            }
+        }
+    }
+    
+    fileprivate func getTopMostCoordinate(list: [CGPoint]) -> CGFloat {
+        assert(list.count > 0)
+        let firstCoordinate = list[0].y
+        return list.dropFirst().reduce(firstCoordinate, { (bestCoordinate, otherCoordinates) -> CGFloat in
+            return (otherCoordinates.y < bestCoordinate) ? otherCoordinates.y : bestCoordinate
+        })
+    }
+    
+    fileprivate func getBottomMostCoordinate(list: [CGPoint]) -> CGFloat {
+        assert(list.count > 0)
+        let firstCoordinate = list[0].y
+        return list.dropFirst().reduce(firstCoordinate, { (bestCoordinate, otherCoordinates) -> CGFloat in
+            return (otherCoordinates.y > bestCoordinate) ? otherCoordinates.y : bestCoordinate
+        })
+    }
+    
+    fileprivate func getLeftMostCoordinate(list: [CGPoint]) -> CGFloat {
+        assert(list.count > 0)
+        let firstCoordinate = list[0].x
+        return list.dropFirst().reduce(firstCoordinate, { (bestCoordinate, otherCoordinates) -> CGFloat in
+            return (otherCoordinates.x < bestCoordinate) ? otherCoordinates.x : bestCoordinate
+        })
+    }
+    
+    fileprivate func getRightMostCoordinate(list: [CGPoint]) -> CGFloat {
+        assert(list.count > 0)
+        let firstCoordinate = list[0].x
+        return list.dropFirst().reduce(firstCoordinate, { (bestCoordinate, otherCoordinates) -> CGFloat in
+            return (otherCoordinates.x > bestCoordinate) ? otherCoordinates.x : bestCoordinate
+        })
+    }
+    
+    fileprivate func getAverageHCenterCoordinate(list: [CGPoint]) -> CGFloat {
+        assert(list.count > 0)
+        let sum = list.reduce(0, { (result, point) -> CGFloat in
+            return result + point.x
+        })
+        return sum / CGFloat(list.count)
+    }
+    
+    fileprivate func getAverageVCenterCoordinate(list: [CGPoint]) -> CGFloat {
+        assert(list.count > 0)
+        let sum = list.reduce(0, { (result, point) -> CGFloat in
+            return result + point.y
+        })
+        return sum / CGFloat(list.count)
+    }
+    
+    fileprivate func validateRelativeViews(_ relativeViews: [UIView], context: Context) -> [UIView]? {
+        guard let _ = layoutSuperview(context) else { return nil }
+        guard relativeViews.count > 0 else {
+            warn("At least one view must be visible (i.e. UIView.isHidden != true) ", context)
+            return nil
+        }
+        
+        return relativeViews
+    }
+}
+
+#endif

--- a/Sources/PinLayoutImpl+Warning.swift
+++ b/Sources/PinLayoutImpl+Warning.swift
@@ -1,0 +1,66 @@
+//
+//  PinLayoutImpl+Warning.swift
+//  PinLayout
+//
+//  Created by DION, Luc (MTL) on 2017-06-17.
+//  Copyright © 2017 mcswiftlayyout.mirego.com. All rights reserved.
+//
+#if os(iOS) || os(tvOS)
+import UIKit
+
+extension PinLayoutImpl {
+    internal func pointContext(method: String, point: CGPoint) -> String {
+        return "\(method)(to: CGPoint(x: \(point.x), y: \(point.y)))"
+    }
+    
+    internal func relativeEdgeContext(method: String, edge: VerticalEdge) -> String {
+        let edge = edge as! VerticalEdgeImpl
+        return "\(method)(to: \(edge.type.rawValue), of: \(edge.view))"
+    }
+    
+    internal func relativeEdgeContext(method: String, edge: HorizontalEdge) -> String {
+        let edge = edge as! HorizontalEdgeImpl
+        return "\(method)(to: \(edge.type.rawValue), of: \(edge.view))"
+    }
+    
+    internal func relativeAnchorContext(method: String, anchor: Anchor) -> String {
+        let anchor = anchor as! AnchorImpl
+        return "\(method)(to: \(anchor.type.rawValue), of: \(anchor.view))"
+    }
+    
+    internal func warn(_ text: String, _ context: Context) {
+        guard PinLayoutLogConflicts else { return }
+        displayWarning("\n👉 PinLayout Warning: \(context()) won't be applied, \(text)\n")
+    }
+    
+    internal func warnPropertyAlreadySet(_ propertyName: String, propertyValue: CGFloat, _ context: Context) {
+        guard PinLayoutLogConflicts else { return }
+        displayWarning("\n👉 PinLayout Conflict: \(context()) won't be applied since it value has already been set to \(propertyValue).\n")
+    }
+    
+    internal func warnPropertyAlreadySet(_ propertyName: String, propertyValue: CGSize, _ context: Context) {
+        guard PinLayoutLogConflicts else { return }
+        displayWarning("\n👉 PinLayout Conflict: \(context()) won't be applied since it value has already been set to CGSize(width: \(propertyValue.width), height: \(propertyValue.height)).\n")
+    }
+    
+    internal func warnConflict(_ context: Context, _ properties: [String: CGFloat]) {
+        guard PinLayoutLogConflicts else { return }
+        var warning = "\n👉 PinLayout Conflict: \(context()) won't be applied since it conflicts with the following already set properties:\n"
+        properties.forEach { (key, value) in
+            warning += " \(key): \(value)\n"
+        }
+        
+        displayWarning(warning)
+    }
+    
+    internal func displayWarning(_ text: String) {
+        print(text)
+        unitTestLastWarning = text
+    }
+    
+    internal func viewDescription(_ view: UIView) -> String {
+        return "\"\(view.description)\""
+    }
+}
+
+#endif

--- a/Sources/PinLayoutImpl.swift
+++ b/Sources/PinLayoutImpl.swift
@@ -38,31 +38,31 @@ public var unitTestLastWarning: String?
 #endif
 
 class PinLayoutImpl: PinLayout {
-    fileprivate let view: UIView
+    internal let view: UIView
 
-    fileprivate var _top: CGFloat?       // offset from superview's top edge
-    fileprivate var _left: CGFloat?      // offset from superview's left edge
-    fileprivate var _bottom: CGFloat?    // offset from superview's top edge
-    fileprivate var _right: CGFloat?     // offset from superview's left edge
+    internal var _top: CGFloat?       // offset from superview's top edge
+    internal var _left: CGFloat?      // offset from superview's left edge
+    internal var _bottom: CGFloat?    // offset from superview's top edge
+    internal var _right: CGFloat?     // offset from superview's left edge
     
-    fileprivate var _hCenter: CGFloat?
-    fileprivate var _vCenter: CGFloat?
+    internal var _hCenter: CGFloat?
+    internal var _vCenter: CGFloat?
     
-    fileprivate var width: CGFloat?
-    fileprivate var height: CGFloat?
+    internal var width: CGFloat?
+    internal var height: CGFloat?
 
-    fileprivate var marginTop: CGFloat?
-    fileprivate var marginLeft: CGFloat?
-    fileprivate var marginBottom: CGFloat?
-    fileprivate var marginRight: CGFloat?
-    fileprivate var shouldPinEdges = false
+    internal var marginTop: CGFloat?
+    internal var marginLeft: CGFloat?
+    internal var marginBottom: CGFloat?
+    internal var marginRight: CGFloat?
+    internal var shouldPinEdges = false
     
-    fileprivate var shouldSizeToFit = false
+    internal var shouldSizeToFit = false
 
-    fileprivate var _marginTop: CGFloat { return marginTop ?? 0  }
-    fileprivate var _marginLeft: CGFloat { return marginLeft ?? 0 }
-    fileprivate var _marginBottom: CGFloat { return marginBottom ?? 0 }
-    fileprivate var _marginRight: CGFloat { return marginRight ?? 0 }
+    internal var _marginTop: CGFloat { return marginTop ?? 0  }
+    internal var _marginLeft: CGFloat { return marginLeft ?? 0 }
+    internal var _marginBottom: CGFloat { return marginBottom ?? 0 }
+    internal var _marginRight: CGFloat { return marginRight ?? 0 }
 
     init(view: UIView) {
         self.view = view
@@ -427,155 +427,6 @@ class PinLayoutImpl: PinLayout {
         setRight(layoutSuperview.frame.width, context)
         return self
     }
-
-    /// Set the view's bottom coordinate above all specified views.
-    @discardableResult
-    func above(of relativeViews: UIView...) -> PinLayout {
-        func context() -> String { return "above(of: UIView...)" }
-        guard validateRelativeViewsCount(relativeViews, context: context) else { return self }
-        
-        let anchors = relativeViews.map({ $0.anchor.topLeft })
-        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
-            setBottom(getTopMostCoordinate(list: coordinatesList), context)
-        }
-        return self
-    }
-
-    /// Set the view's bottom coordinate above all specified view.
-    @discardableResult
-    func above(of relativeViews: UIView..., aligned: HorizontalAlignment) -> PinLayout {
-        func context() -> String { return "above(of: UIView..., aligned: \(aligned))" }
-        guard validateRelativeViewsCount(relativeViews, context: context) else { return self }
-        
-        let anchors: [Anchor]
-        switch aligned {
-        case .left:   anchors = relativeViews.map({ $0.anchor.topLeft })
-        case .center: anchors = relativeViews.map({ $0.anchor.topCenter })
-        case .right:  anchors = relativeViews.map({ $0.anchor.topRight })
-        }
-        
-        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
-            setBottom(getTopMostCoordinate(list: coordinatesList), context)
-            
-            switch aligned {
-            case .left:   setLeft(getLeftMostCoordinate(list: coordinatesList), context)
-            case .center: setHorizontalCenter(getAverageHCenterCoordinate(list: coordinatesList), context)
-            case .right:  setRight(getRightMostCoordinate(list: coordinatesList), context)
-            }
-        }
-        return self
-    }
-    
-    /// Set the view's top coordinate below all specified view.
-    @discardableResult
-    func below(of relativeViews: UIView...) -> PinLayout {
-        func context() -> String { return "below(of: UIView...)" }
-        guard validateRelativeViewsCount(relativeViews, context: context) else { return self }
-        
-        let anchors = relativeViews.map({ $0.anchor.bottomLeft })
-        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
-            setTop(getBottomMostCoordinate(list: coordinatesList), context)
-        }
-        return self
-    }
-    
-    @discardableResult
-    func below(of relativeViews: UIView..., aligned: HorizontalAlignment) -> PinLayout {
-        func context() -> String { return "below(of: UIView..., aligned: \(aligned))" }
-        guard validateRelativeViewsCount(relativeViews, context: context) else { return self }
-        
-        let anchors: [Anchor]
-        switch aligned {
-        case .left:   anchors = relativeViews.map({ $0.anchor.bottomLeft })
-        case .center: anchors = relativeViews.map({ $0.anchor.bottomCenter })
-        case .right:  anchors = relativeViews.map({ $0.anchor.bottomRight })
-        }
-        
-        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
-            setTop(getBottomMostCoordinate(list: coordinatesList), context)
-            
-            switch aligned {
-            case .left:   setLeft(getLeftMostCoordinate(list: coordinatesList), context)
-            case .center: setHorizontalCenter(getAverageHCenterCoordinate(list: coordinatesList), context)
-            case .right:  setRight(getRightMostCoordinate(list: coordinatesList), context)
-            }
-        }
-        return self
-    }
-    
-    /// Set the view's right coordinate left of the specified view.
-    @discardableResult
-    func left(of relativeViews: UIView...) -> PinLayout {
-        func context() -> String { return "left(of: UIView...)" }
-        guard validateRelativeViewsCount(relativeViews, context: context) else { return self }
-        
-        let anchors = relativeViews.map({ $0.anchor.topLeft })
-        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
-            setRight(getLeftMostCoordinate(list: coordinatesList), context)
-        }
-        return self
-    }
-    
-    @discardableResult
-    func left(of relativeViews: UIView..., aligned: VerticalAlignment) -> PinLayout {
-        func context() -> String { return "left(of: UIView..., aligned: \(aligned))" }
-        guard validateRelativeViewsCount(relativeViews, context: context) else { return self }
-        
-        let anchors: [Anchor]
-        switch aligned {
-        case .top:    anchors = relativeViews.map({ $0.anchor.topLeft })
-        case .center: anchors = relativeViews.map({ $0.anchor.leftCenter })
-        case .bottom: anchors = relativeViews.map({ $0.anchor.bottomLeft })
-        }
-        
-        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
-            setRight(getLeftMostCoordinate(list: coordinatesList), context)
-            
-            switch aligned {
-            case .top:    setTop(getTopMostCoordinate(list: coordinatesList), context)
-            case .center: setVerticalCenter(getAverageVCenterCoordinate(list: coordinatesList), context)
-            case .bottom: setBottom(getBottomMostCoordinate(list: coordinatesList), context)
-            }
-        }
-        return self
-    }
-    
-    /// Set the view's left coordinate right of the specified view.
-    @discardableResult
-    func right(of relativeViews: UIView...) -> PinLayout {
-        func context() -> String { return "right(of: UIView...)" }
-        guard validateRelativeViewsCount(relativeViews, context: context) else { return self }
-        
-        let anchors = relativeViews.map({ $0.anchor.topRight })
-        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
-            setLeft(getRightMostCoordinate(list: coordinatesList), context)
-        }
-        return self
-    }
-    
-    @discardableResult
-    func right(of relativeViews: UIView..., aligned: VerticalAlignment) -> PinLayout {
-        func context() -> String { return "right(of: UIView..., aligned: \(aligned))" }
-        guard validateRelativeViewsCount(relativeViews, context: context) else { return self }
-        
-        let anchors: [Anchor]
-        switch aligned {
-        case .top:    anchors = relativeViews.map({ $0.anchor.topRight })
-        case .center: anchors = relativeViews.map({ $0.anchor.rightCenter })
-        case .bottom: anchors = relativeViews.map({ $0.anchor.bottomRight })
-        }
-        
-        if let coordinatesList = computeCoordinates(forAnchors: anchors, context) {
-            setLeft(getRightMostCoordinate(list: coordinatesList), context)
-            
-            switch aligned {
-            case .top:    setTop(getTopMostCoordinate(list: coordinatesList), context)
-            case .center: setVerticalCenter(getAverageVCenterCoordinate(list: coordinatesList), context)
-            case .bottom: setBottom(getBottomMostCoordinate(list: coordinatesList), context)
-            }
-        }
-        return self
-    }
     
     //
     // width, height
@@ -729,225 +580,10 @@ class PinLayoutImpl: PinLayout {
 }
 
 //
-// MARK: Private methods - Set coordinates
+// MARK: Private methods
 //
 extension PinLayoutImpl {
-    fileprivate func setTop(_ value: CGFloat, _ context: Context) {
-        if let _bottom = _bottom, let height = height {
-            warnConflict(context, ["bottom": _bottom, "height": height])
-        } else if let _vCenter = _vCenter {
-            warnConflict(context, ["Vertical Center": _vCenter])
-        } else if let _top = _top, _top != value {
-            warnPropertyAlreadySet("top", propertyValue: _top, context)
-        } else {
-            _top = value
-        }
-    }
-    
-    fileprivate func setLeft(_ value: CGFloat, _ context: Context) {
-        if let _right = _right, let width = width  {
-            warnConflict(context, ["right": _right, "width": width])
-        } else if let _hCenter = _hCenter {
-            warnConflict(context, ["Horizontal Center": _hCenter])
-        } else if let _left = _left, _left != value {
-            warnPropertyAlreadySet("left", propertyValue: _left, context)
-        } else {
-            _left = value
-        }
-    }
-    
-    fileprivate func setRight(_ value: CGFloat, _ context: Context) {
-        if let _left = _left, let width = width  {
-            warnConflict(context, ["left": _left, "width": width])
-        } else if let _hCenter = _hCenter {
-            warnConflict(context, ["Horizontal Center": _hCenter])
-        } else if let _right = _right, _right != value {
-            warnPropertyAlreadySet("right", propertyValue: _right, context)
-        } else {
-            _right = value
-        }
-    }
-    
-    fileprivate func setBottom(_ value: CGFloat, _ context: Context) {
-        if let _top = _top, let height = height {
-            warnConflict(context, ["top": _top, "height": height])
-        } else if let _vCenter = _vCenter {
-            warnConflict(context, ["Vertical Center": _vCenter])
-        } else if let _bottom = _bottom, _bottom != value {
-            warnPropertyAlreadySet("bottom", propertyValue: _bottom, context)
-        } else {
-            _bottom = value
-        }
-    }
-
-    fileprivate func setHorizontalCenter(_ value: CGFloat, _ context: Context) {
-        if let _left = _left {
-            warnConflict(context, ["left": _left])
-        } else if let _right = _right {
-            warnConflict(context, ["right": _right])
-        } else if let _hCenter = _hCenter, _hCenter != value {
-            warnPropertyAlreadySet("Horizontal Center", propertyValue: _hCenter, context)
-        } else {
-            _hCenter = value
-        }
-    }
-    
-    fileprivate func setVerticalCenter(_ value: CGFloat, _ context: Context) {
-        if let _top = _top {
-            warnConflict(context, ["top": _top])
-        } else if let _bottom = _bottom {
-            warnConflict(context, ["bottom": _bottom])
-        } else if let _vCenter = _vCenter, _vCenter != value {
-            warnPropertyAlreadySet("Vertical Center", propertyValue: _vCenter, context)
-        } else {
-            _vCenter = value
-        }
-    }
-    
-    @discardableResult
-    fileprivate func setTopLeft(_ point: CGPoint, _ context: Context) -> PinLayout {
-        setLeft(point.x, context)
-        setTop(point.y, context)
-        return self
-    }
-    
-    @discardableResult
-    fileprivate func setTopCenter(_ point: CGPoint, _ context: Context) -> PinLayout {
-        setHorizontalCenter(point.x, context)
-        setTop(point.y, context)
-        return self
-    }
-    
-    @discardableResult
-    fileprivate func setTopRight(_ point: CGPoint, _ context: Context) -> PinLayout {
-        setRight(point.x, context)
-        setTop(point.y, context)
-        return self
-    }
-    
-    @discardableResult
-    fileprivate func setLeftCenter(_ point: CGPoint, _ context: Context) -> PinLayout {
-        setLeft(point.x, context)
-        setVerticalCenter(point.y, context)
-        return self
-    }
-    
-    @discardableResult
-    fileprivate func setCenter(_ point: CGPoint, _ context: Context) -> PinLayout {
-        setHorizontalCenter(point.x, context)
-        setVerticalCenter(point.y, context)
-        return self
-    }
-    
-    @discardableResult
-    fileprivate func setRightCenter(_ point: CGPoint, _ context: Context) -> PinLayout {
-        setRight(point.x, context)
-        setVerticalCenter(point.y, context)
-        return self
-    }
-    
-    @discardableResult
-    fileprivate func setBottomLeft(_ point: CGPoint, _ context: Context) -> PinLayout {
-        setLeft(point.x, context)
-        setBottom(point.y, context)
-        return self
-    }
-    
-    @discardableResult
-    fileprivate func setBottomCenter(_ point: CGPoint, _ context: Context) -> PinLayout {
-        setHorizontalCenter(point.x, context)
-        setBottom(point.y, context)
-        return self
-    }
-    
-    @discardableResult
-    fileprivate func setBottomRight(_ point: CGPoint, _ context: Context) -> PinLayout {
-        setRight(point.x, context)
-        setBottom(point.y, context)
-        return self
-    }
-
-    @discardableResult
-    fileprivate func setWidth(_ value: CGFloat, _ context: Context) -> PinLayout {
-        guard value >= 0 else {
-            warn("the width (\(value)) ust be greater than or equal to zero.", context); return self
-        }
-        
-        if let _left = _left, let _right = _right {
-            warnConflict(context, ["left": _left, "right": _right])
-        } else if let width = width, width != value {
-            warnPropertyAlreadySet("width", propertyValue: width, context)
-        } else {
-            width = value
-        }
-        return self
-    }
-    
-    @discardableResult
-    fileprivate func setHeight(_ value: CGFloat, _ context: Context) -> PinLayout {
-        guard value >= 0 else {
-            warn("the height (\(value)) must be greater than or equal to zero.", context); return self
-        }
-        
-        if let _top = _top, let _bottom = _bottom {
-            warnConflict(context, ["top": _top, "bottom": _bottom])
-        } else if let height = height, height != value {
-            warnPropertyAlreadySet("height", propertyValue: height, context)
-        } else {
-            height = value
-        }
-        return self
-    }
-    
-    fileprivate func setSize(_ size: CGSize, _ context: Context) -> PinLayout {
-        setWidth(size.width, { return "\(context())'s width" })
-        setHeight(size.height, { return "\(context())'s height" })
-        return self
-    }
-    
-    fileprivate func computeCoordinates(_ point: CGPoint, _ layoutSuperview: UIView, _ referenceView: UIView, _ referenceSuperview: UIView) -> CGPoint {
-        if layoutSuperview == referenceSuperview {
-            return point   // same superview => no coordinates conversion required.
-        } else {
-            return referenceSuperview.convert(point, to: layoutSuperview)
-        }
-    }
-    
-    fileprivate func computeCoordinates(forAnchors anchors: [Anchor], _ context: Context) -> [CGPoint]? {
-        guard let layoutSuperview = layoutSuperview(context) else { return nil }
-        var results: [CGPoint] = []
-        anchors.forEach({ (anchor) in
-            let anchor = anchor as! AnchorImpl
-            if let referenceSuperview = referenceSuperview(anchor.view, context) {
-                results.append(computeCoordinates(anchor.point, layoutSuperview, anchor.view, referenceSuperview))
-            }
-        })
-        
-        guard results.count > 0 else {
-            warn("no valid references", context)
-            return nil
-        }
-        
-        return results
-    }
-    
-    fileprivate func computeCoordinate(forEdge edge: HorizontalEdge, _ context: Context) -> CGFloat? {
-        let edge = edge as! HorizontalEdgeImpl
-        guard let layoutSuperview = layoutSuperview(context) else { return nil }
-        guard let referenceSuperview = referenceSuperview(edge.view, context) else { return nil }
-        
-        return computeCoordinates(CGPoint(x: edge.x, y: 0), layoutSuperview, edge.view, referenceSuperview).x
-    }
-
-    fileprivate func computeCoordinate(forEdge edge: VerticalEdge, _ context: Context) -> CGFloat? {
-        let edge = edge as! VerticalEdgeImpl
-        guard let layoutSuperview = layoutSuperview(context) else { return nil }
-        guard let referenceSuperview = referenceSuperview(edge.view, context) else { return nil }
-
-        return computeCoordinates(CGPoint(x: 0, y: edge.y), layoutSuperview, edge.view, referenceSuperview).y
-    }
-
-    fileprivate func layoutSuperview(_ context: Context) -> UIView? {
+    internal func layoutSuperview(_ context: Context) -> UIView? {
         if let superview = view.superview {
             return superview
         } else {
@@ -956,7 +592,7 @@ extension PinLayoutImpl {
         }
     }
 
-    fileprivate func referenceSuperview(_ referenceView: UIView, _ context: Context) -> UIView? {
+    internal func referenceSuperview(_ referenceView: UIView, _ context: Context) -> UIView? {
         if let superview = referenceView.superview {
             return superview
         } else {
@@ -965,69 +601,8 @@ extension PinLayoutImpl {
         }
     }
 }
-    
-// MARK - Relative methods helpers
-extension PinLayoutImpl {
-    fileprivate func getTopMostCoordinate(list: [CGPoint]) -> CGFloat {
-        assert(list.count > 0)
-        let firstCoordinate = list[0].y
-        return list.dropFirst().reduce(firstCoordinate, { (bestCoordinate, otherCoordinates) -> CGFloat in
-            return (otherCoordinates.y < bestCoordinate) ? otherCoordinates.y : bestCoordinate
-        })
-    }
-    
-    fileprivate func getBottomMostCoordinate(list: [CGPoint]) -> CGFloat {
-        assert(list.count > 0)
-        let firstCoordinate = list[0].y
-        return list.dropFirst().reduce(firstCoordinate, { (bestCoordinate, otherCoordinates) -> CGFloat in
-            return (otherCoordinates.y > bestCoordinate) ? otherCoordinates.y : bestCoordinate
-        })
-    }
-    
-    fileprivate func getLeftMostCoordinate(list: [CGPoint]) -> CGFloat {
-        assert(list.count > 0)
-        let firstCoordinate = list[0].x
-        return list.dropFirst().reduce(firstCoordinate, { (bestCoordinate, otherCoordinates) -> CGFloat in
-            return (otherCoordinates.x < bestCoordinate) ? otherCoordinates.x : bestCoordinate
-        })
-    }
-    
-    fileprivate func getRightMostCoordinate(list: [CGPoint]) -> CGFloat {
-        assert(list.count > 0)
-        let firstCoordinate = list[0].x
-        return list.dropFirst().reduce(firstCoordinate, { (bestCoordinate, otherCoordinates) -> CGFloat in
-            return (otherCoordinates.x > bestCoordinate) ? otherCoordinates.x : bestCoordinate
-        })
-    }
-    
-    fileprivate func getAverageHCenterCoordinate(list: [CGPoint]) -> CGFloat {
-        assert(list.count > 0)
-        let sum = list.reduce(0, { (result, point) -> CGFloat in
-            return result + point.x
-        })
-        return sum / CGFloat(list.count)
-    }
-    
-    fileprivate func getAverageVCenterCoordinate(list: [CGPoint]) -> CGFloat {
-        assert(list.count > 0)
-        let sum = list.reduce(0, { (result, point) -> CGFloat in
-            return result + point.y
-        })
-        return sum / CGFloat(list.count)
-    }
-    
-    fileprivate func validateRelativeViewsCount(_ views: [UIView], context: Context) -> Bool {
-        guard let _ = layoutSuperview(context) else { return false }
-        guard views.count > 0 else {
-            warn("At least one view must be specified", context)
-            return false
-        }
-        
-        return true
-    }
-}
 
-// MARK - UIView's frame compuation methods
+// MARK - UIView's frame computation methods
 extension PinLayoutImpl {
     fileprivate func apply() {
         apply(onView: view)
@@ -1219,59 +794,6 @@ extension PinLayoutImpl {
         } else {
             return nil
         }
-    }
-
-    fileprivate func pointContext(method: String, point: CGPoint) -> String {
-        return "\(method)(to: CGPoint(x: \(point.x), y: \(point.y)))"
-    }
-
-    fileprivate func relativeEdgeContext(method: String, edge: VerticalEdge) -> String {
-        let edge = edge as! VerticalEdgeImpl
-        return "\(method)(to: \(edge.type.rawValue), of: \(edge.view))"
-    }
-
-    fileprivate func relativeEdgeContext(method: String, edge: HorizontalEdge) -> String {
-        let edge = edge as! HorizontalEdgeImpl
-        return "\(method)(to: \(edge.type.rawValue), of: \(edge.view))"
-    }
-
-    fileprivate func relativeAnchorContext(method: String, anchor: Anchor) -> String {
-        let anchor = anchor as! AnchorImpl
-        return "\(method)(to: \(anchor.type.rawValue), of: \(anchor.view))"
-    }
-
-    fileprivate func warn(_ text: String, _ context: Context) {
-        guard PinLayoutLogConflicts else { return }
-        displayWarning("\n👉 PinLayout Warning: \(context()) won't be applied, \(text)\n")
-    }
-    
-    fileprivate func warnPropertyAlreadySet(_ propertyName: String, propertyValue: CGFloat, _ context: Context) {
-        guard PinLayoutLogConflicts else { return }
-        displayWarning("\n👉 PinLayout Conflict: \(context()) won't be applied since it value has already been set to \(propertyValue).\n")
-    }
-    
-    fileprivate func warnPropertyAlreadySet(_ propertyName: String, propertyValue: CGSize, _ context: Context) {
-        guard PinLayoutLogConflicts else { return }
-        displayWarning("\n👉 PinLayout Conflict: \(context()) won't be applied since it value has already been set to CGSize(width: \(propertyValue.width), height: \(propertyValue.height)).\n")
-    }
-    
-    fileprivate func warnConflict(_ context: Context, _ properties: [String: CGFloat]) {
-        guard PinLayoutLogConflicts else { return }
-        var warning = "\n👉 PinLayout Conflict: \(context()) won't be applied since it conflicts with the following already set properties:\n"
-        properties.forEach { (key, value) in
-            warning += " \(key): \(value)\n"
-        }
-        
-        displayWarning(warning)
-    }
-    
-    fileprivate func displayWarning(_ text: String) {
-        print(text)
-        unitTestLastWarning = text
-    }
-    
-    fileprivate func viewDescription(_ view: UIView) -> String {
-        return "\"\(view.description)\""
     }
 }
     

--- a/Tests/RelativePositionMultipleViewsSpec.swift
+++ b/Tests/RelativePositionMultipleViewsSpec.swift
@@ -90,14 +90,14 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             
             it("should warns the view bottom edge") {
                 let unatachedView = UIView()
-                bViewChild.pin.above(of: aView, unatachedView)
+                bViewChild.pin.above(of: [aView, unatachedView])
                 expect(bViewChild.frame).to(equal(CGRect(x: 40.0, y: -40.0, width: 60.0, height: 20.0)))
                 expect(unitTestLastWarning).to(contain(["above", "won't be applied", "the reference view", "must be added", "as a reference"]))
             }
             
             it("Should warn, but the view should be anyway layout it above") {
                 let unatachedView = UIView()
-                bViewChild.pin.above(of: aView, unatachedView)
+                bViewChild.pin.above(of: [aView, unatachedView])
                 expect(bViewChild.frame).to(equal(CGRect(x: 40.0, y: -40.0, width: 60.0, height: 20.0)))
                 expect(unitTestLastWarning).to(contain(["above", "won't be applied", "the reference view", "must be added", "as a reference"]))
             }
@@ -113,17 +113,17 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             }
 
             it("should move the view above relative views") {
-                bViewChild.pin.above(of: aView, bView)
+                bViewChild.pin.above(of: [aView, bView])
                 expect(bViewChild.frame).to(equal(CGRect(x: 40.0, y: -40.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view above relative views") {
-                bViewChild.pin.above(of: aView, bView, aligned: .left)
+                bViewChild.pin.above(of: [aView, bView], aligned: .left)
                 expect(bViewChild.frame).to(equal(CGRect(x: -120.0, y: -40.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view above relative views") {
-                bViewChild.pin.above(of: aView, bView, aligned: .right)
+                bViewChild.pin.above(of: [aView, bView], aligned: .right)
                 expect(bViewChild.frame).to(equal(CGRect(x: 50.0, y: -40.0, width: 60.0, height: 20.0)))
             }
 
@@ -133,17 +133,17 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             }
 
             it("should move the view above relative views") {
-                bViewChild.pin.above(of: aView, bView, aligned: .center)
+                bViewChild.pin.above(of: [aView, bView], aligned: .center)
                 expect(bViewChild.frame).to(equal(CGRect(x: -37.5, y: -40.0, width: 60.0, height: 20.0)))
             }
 
             it("should move the view above relative views") {
-                bViewChild.pin.above(of: aView, bView, aligned: .right).margin(10)
+                bViewChild.pin.above(of: [aView, bView], aligned: .right).margin(10)
                 expect(bViewChild.frame).to(equal(CGRect(x: 40.0, y: -50.0, width: 60.0, height: 20.0)))
             }
 
             it("should move the view above relative views") {
-                bViewChild.pin.above(of: aView, bView, aligned: .left).margin(10)
+                bViewChild.pin.above(of: [aView, bView], aligned: .left).margin(10)
                 expect(bViewChild.frame).to(equal(CGRect(x: -110.0, y: -50.0, width: 60.0, height: 20.0)))
             }
         }
@@ -158,17 +158,17 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             }
             
             it("should move the view below relative views") {
-                bViewChild.pin.below(of: aView, bView)
+                bViewChild.pin.below(of: [aView, bView])
                 expect(bViewChild.frame).to(equal(CGRect(x: 40.0, y: 80.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view below relative views") {
-                bViewChild.pin.below(of: aView, bView, aligned: .left)
+                bViewChild.pin.below(of: [aView, bView], aligned: .left)
                 expect(bViewChild.frame).to(equal(CGRect(x: -120.0, y: 80.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view below relative views") {
-                bViewChild.pin.below(of: aView, bView, aligned: .right)
+                bViewChild.pin.below(of: [aView, bView], aligned: .right)
                 expect(bViewChild.frame).to(equal(CGRect(x: 50.0, y: 80.0, width: 60.0, height: 20.0)))
             }
             
@@ -178,22 +178,22 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             }
             
             it("should move the view below relative views") {
-                bViewChild.pin.below(of: aView, bView, aligned: .center)
+                bViewChild.pin.below(of: [aView, bView], aligned: .center)
                 expect(bViewChild.frame).to(equal(CGRect(x: -37.5, y: 80.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view below relative views") {
-                bViewChild.pin.below(of: aView, bView, aligned: .right).margin(10)
+                bViewChild.pin.below(of: [aView, bView], aligned: .right).margin(10)
                 expect(bViewChild.frame).to(equal(CGRect(x: 40.0, y: 90.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view below relative views") {
-                bViewChild.pin.below(of: aView, bView, aligned: .left).margin(10)
+                bViewChild.pin.below(of: [aView, bView], aligned: .left).margin(10)
                 expect(bViewChild.frame).to(equal(CGRect(x: -110.0, y: 90.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view below relative views") {
-                bViewChild.pin.below(of: aView, bView, aligned: .center).margin(10)
+                bViewChild.pin.below(of: [aView, bView], aligned: .center).margin(10)
                 expect(bViewChild.frame).to(equal(CGRect(x: -37.5, y: 90.0, width: 60.0, height: 20.0)))
             }
         }
@@ -208,22 +208,22 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             }
             
             it("should move the view left relative views") {
-                bViewChild.pin.left(of: aView, bView)
+                bViewChild.pin.left(of: [aView, bView])
                 expect(bViewChild.frame).to(equal(CGRect(x: -180.0, y: 10.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view left relative views") {
-                bViewChild.pin.left(of: bView, bView)
+                bViewChild.pin.left(of: [bView, bView])
                 expect(bViewChild.frame).to(equal(CGRect(x: -60.0, y: 10.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view left relative views") {
-                bViewChild.pin.left(of: aView, bView, aligned: .top)
+                bViewChild.pin.left(of: [aView, bView], aligned: .top)
                 expect(bViewChild.frame).to(equal(CGRect(x: -180.0, y: -20.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view left relative views") {
-                bViewChild.pin.left(of: aView, bView, aligned: .bottom)
+                bViewChild.pin.left(of: [aView, bView], aligned: .bottom)
                 expect(bViewChild.frame).to(equal(CGRect(x: -180.0, y: 60.0, width: 60.0, height: 20.0)))
             }
             
@@ -233,22 +233,22 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             }
             
             it("should move the view left relative views") {
-                bViewChild.pin.left(of: aView, bView, aligned: .center)
+                bViewChild.pin.left(of: [aView, bView], aligned: .center)
                 expect(bViewChild.frame).to(equal(CGRect(x: -180.0, y: 15.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view left relative views") {
-                bViewChild.pin.left(of: aView, bView, aligned: .bottom).margin(10)
+                bViewChild.pin.left(of: [aView, bView], aligned: .bottom).margin(10)
                 expect(bViewChild.frame).to(equal(CGRect(x: -190.0, y: 50.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view left relative views") {
-                bViewChild.pin.left(of: aView, bView, aligned: .top).margin(10)
+                bViewChild.pin.left(of: [aView, bView], aligned: .top).margin(10)
                 expect(bViewChild.frame).to(equal(CGRect(x: -190.0, y: -10.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view left relative views") {
-                bViewChild.pin.left(of: aView, bView, aligned: .center).margin(10)
+                bViewChild.pin.left(of: [aView, bView], aligned: .center).margin(10)
                 expect(bViewChild.frame).to(equal(CGRect(x: -190.0, y: 15.0, width: 60.0, height: 20.0)))
             }
         }
@@ -263,17 +263,17 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             }
             
             it("should move the view right relative views") {
-                bViewChild.pin.right(of: aView, bView)
+                bViewChild.pin.right(of: [aView, bView])
                 expect(bViewChild.frame).to(equal(CGRect(x: 110.0, y: 10.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view right relative views") {
-                bViewChild.pin.right(of: aView, bView, aligned: .top)
+                bViewChild.pin.right(of: [aView, bView], aligned: .top)
                 expect(bViewChild.frame).to(equal(CGRect(x: 110.0, y: -20.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view right relative views") {
-                bViewChild.pin.right(of: aView, bView, aligned: .bottom)
+                bViewChild.pin.right(of: [aView, bView], aligned: .bottom)
                 expect(bViewChild.frame).to(equal(CGRect(x: 110.0, y: 60.0, width: 60.0, height: 20.0)))
             }
             
@@ -283,22 +283,22 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             }
             
             it("should move the view right relative views") {
-                bViewChild.pin.right(of: aView, bView, aligned: .center)
+                bViewChild.pin.right(of: [aView, bView], aligned: .center)
                 expect(bViewChild.frame).to(equal(CGRect(x: 110.0, y: 15.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view right relative views") {
-                bViewChild.pin.right(of: aView, bView, aligned: .bottom).margin(10)
+                bViewChild.pin.right(of: [aView, bView], aligned: .bottom).margin(10)
                 expect(bViewChild.frame).to(equal(CGRect(x: 120.0, y: 50.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view right relative views") {
-                bViewChild.pin.right(of: aView, bView, aligned: .top).margin(10)
+                bViewChild.pin.right(of: [aView, bView], aligned: .top).margin(10)
                 expect(bViewChild.frame).to(equal(CGRect(x: 120.0, y: -10.0, width: 60.0, height: 20.0)))
             }
             
             it("should move the view right relative views") {
-                bViewChild.pin.right(of: aView, bView, aligned: .center).margin(10)
+                bViewChild.pin.right(of: [aView, bView], aligned: .center).margin(10)
                 expect(bViewChild.frame).to(equal(CGRect(x: 120.0, y: 15.0, width: 60.0, height: 20.0)))
             }
         }     

--- a/Tests/RelativePositionSpec.swift
+++ b/Tests/RelativePositionSpec.swift
@@ -90,8 +90,8 @@ class RelativePositionSpec: QuickSpec {
         //
         describe("the result of above(of:aligned: left)") {
             it("should adjust the bView position relative to its sibling (aView)") {
-                bView.pin.above(of: aView, aViewChild)
-                bView.pin.above(of: aView, aViewChild, aligned: .left)
+                bView.pin.above(of: [aView, aViewChild])
+                bView.pin.above(of: [aView, aViewChild], aligned: .left)
                 expect(bView.frame).to(equal(CGRect(x: 100.0, y: 60.0, width: 40.0, height: 40.0)))
             }
             


### PR DESCRIPTION
Instead of having a variadic parameter, method `above(of…)`, `below(of…)`, `left(of…)` and `right(of…)` now takes either a single UIView or an Array of UIViews.
This make it easier to call these methods if the developper has already an array of UIViews. Variadic parameters are quite limited in Swift, they don’t accept an Array, which other language accept.

Plus:
* Refactor source code to split PinLayout’s implementation in multiple files.