### PR TITLE
Undo recent changes to method margin(CGFloat, CGFloat, CGFloat, CGFloat)

### DIFF
--- a/Sources/PinLayout.swift
+++ b/Sources/PinLayout.swift
@@ -270,7 +270,7 @@ public protocol PinLayout {
     ///   - bottom: <#bottom description#>
     ///   - right: <#right description#>
     /// - Returns: <#return value description#>
-    @discardableResult func margin(_ top: CGFloat, _ right: CGFloat, _ bottom: CGFloat, _ left: CGFloat) -> PinLayout
+    @discardableResult func margin(_ top: CGFloat, _ left: CGFloat, _ bottom: CGFloat, _ right: CGFloat) -> PinLayout
 
     /// Normally if only either left or right has been specified, PinLayout will MOVE the view to apply left or right margins.
     /// This is also true even if the width has been set.

--- a/Sources/PinLayoutImpl.swift
+++ b/Sources/PinLayoutImpl.swift
@@ -619,7 +619,7 @@ class PinLayoutImpl: PinLayout {
     }
 
     @discardableResult
-    func margin(_ top: CGFloat, _ right: CGFloat, _ bottom: CGFloat, _ left: CGFloat) -> PinLayout {
+    func margin(_ top: CGFloat, _ left: CGFloat, _ bottom: CGFloat, _ right: CGFloat) -> PinLayout {
         marginTop = top
         marginLeft = left
         marginBottom = bottom
@@ -889,7 +889,7 @@ extension PinLayoutImpl {
     
     fileprivate func applyJustify(rect: CGRect, betweenLeft left: CGFloat, andRight right: CGFloat) -> CGRect {
         let containerWidth = right - left - _marginLeft - _marginRight
-        var remainingWidth = containerWidth - rect.width
+        let remainingWidth = containerWidth - rect.width
         var justifyType = HorizontalAlign.left
                 
         if let justify = justify {
@@ -942,7 +942,7 @@ extension PinLayoutImpl {
     
     fileprivate func applyAlign(rect: CGRect, betweenTop top: CGFloat, andBottom bottom: CGFloat) -> CGRect {
         let containerHeight = bottom - top - _marginTop - _marginBottom
-        var remainingHeight = containerHeight - rect.height
+        let remainingHeight = containerHeight - rect.height
         var alignType = VerticalAlign.top
         
         if let align = align {


### PR DESCRIPTION
We finally keep UIEdgeInset order, it is less confusing for iOS developper.