### PR TITLE
Rename sizeToFit to fitSize

### DIFF
--- a/Example/PinLayoutSample/UI/Common/BaseFormView.swift
+++ b/Example/PinLayoutSample/UI/Common/BaseFormView.swift
@@ -61,16 +61,19 @@ class BaseFormView: BaseView {
         formScrollView.contentOffset = CGPoint(x: 0, y: topLayoutGuide)
     }
     
-    @objc internal func keyboardWillShow(notification: Notification) {
+    @objc
+    internal func keyboardWillShow(notification: Notification) {
         guard let sizeValue = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? NSValue else { return }
         setFormScrollView(bottomInset: sizeValue.cgRectValue.height)
     }
     
-    @objc internal func keyboardWillHide(notification: Notification) {
+    @objc
+    internal func keyboardWillHide(notification: Notification) {
         resetScrollOffset()
     }
     
-    @objc internal func didTapScrollView() {
+    @objc
+    internal func didTapScrollView() {
         endEditing(true)
         resetScrollOffset()
     }

--- a/Example/PinLayoutSample/UI/Tests/AdjustToContainer/AdjustToContainerView.swift
+++ b/Example/PinLayoutSample/UI/Tests/AdjustToContainer/AdjustToContainerView.swift
@@ -49,8 +49,8 @@ class AdjustToContainerView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        languageSelectorView.pin.top(topLayoutGuide).left().right().sizeToFit()
-        swiftOpinionSelectorView.pin.below(of: languageSelectorView, aligned: .left).right().marginTop(10).sizeToFit()
-        swiftUsageSelectorView.pin.below(of: swiftOpinionSelectorView, aligned: .left).right().marginTop(10).sizeToFit()
+        languageSelectorView.pin.top(topLayoutGuide).left().right().fitSize()
+        swiftOpinionSelectorView.pin.below(of: languageSelectorView, aligned: .left).right().marginTop(10).fitSize()
+        swiftUsageSelectorView.pin.below(of: swiftOpinionSelectorView, aligned: .left).right().marginTop(10).fitSize()
     }
 }

--- a/Example/PinLayoutSample/UI/Tests/AdjustToContainer/Subviews/ChoiceSelectorView.swift
+++ b/Example/PinLayoutSample/UI/Tests/AdjustToContainer/Subviews/ChoiceSelectorView.swift
@@ -68,10 +68,10 @@ class ChoiceSelectorView: UIView {
         if frame.width > 500 {
             // The UISegmentedControl is at the top-right corner and the label takes the remaining horizontal space.
             segmentedControl.pin.topRight().margin(margin)
-            textLabel.pin.top().left().left(of: segmentedControl).margin(margin).sizeToFit()
+            textLabel.pin.top().left().left(of: segmentedControl).margin(margin).fitSize()
         } else {
             // The UISegmentedControl is placed below the label.
-            textLabel.pin.top().left().right().margin(margin).sizeToFit()
+            textLabel.pin.top().left().right().margin(margin).fitSize()
             segmentedControl.pin.below(of: textLabel).right().margin(margin)
         }
         

--- a/Example/PinLayoutSample/UI/Tests/Form/FormView.swift
+++ b/Example/PinLayoutSample/UI/Tests/Form/FormView.swift
@@ -110,7 +110,8 @@ class FormView: BaseFormView {
         formScrollView.contentSize = formContainerView.frame.size
     }
     
-    @objc internal func didChangeAgeSwitch(uiSwitch: UISwitch) {
+    @objc
+    internal func didChangeAgeSwitch(uiSwitch: UISwitch) {
         // Animate the appearance/disapearance of the age UITextField
         UIView.animate(withDuration: 0.2) { 
             self.ageField.alpha = uiSwitch.isOn ? 1 : 0

--- a/Example/PinLayoutSample/UI/Tests/Intro/IntroView.swift
+++ b/Example/PinLayoutSample/UI/Tests/Intro/IntroView.swift
@@ -66,7 +66,7 @@ class IntroView: BaseView {
         
         logo.pin.top().left().size(100).margin(topLayoutGuide + 10, 10, 10)
         segmented.pin.right(of: logo, aligned: .top).right().marginHorizontal(10)
-        textLabel.pin.below(of: segmented, aligned: .left).width(of: segmented).pinEdges().marginTop(10).sizeToFit()
+        textLabel.pin.below(of: segmented, aligned: .left).width(of: segmented).pinEdges().marginTop(10).fitSize()
         separatorView.pin.below(of: [logo, textLabel], aligned: .left).right(to: segmented.edge.right).marginTop(10)
     }
 }

--- a/Example/PinLayoutSample/UI/Tests/IntroRTL/IntroRTLView.swift
+++ b/Example/PinLayoutSample/UI/Tests/IntroRTL/IntroRTLView.swift
@@ -71,7 +71,7 @@ class IntroRTLView: BaseView {
         
         logo.pin.top().start().size(100).margin(topLayoutGuide + 10, 10, 10, 10)
         segmented.pin.after(of: logo, aligned: .top).end().marginHorizontal(10)
-        textLabel.pin.below(of: segmented, aligned: .start).width(of: segmented).pinEdges().marginTop(10).sizeToFit()
+        textLabel.pin.below(of: segmented, aligned: .start).width(of: segmented).pinEdges().marginTop(10).fitSize()
         separatorView.pin.below(of: [logo, textLabel], aligned: .start).end(to: segmented.edge.end).marginTop(10)
     }
 }

--- a/Example/PinLayoutSample/UI/Tests/TableViewExample/Cells/MethodCell.swift
+++ b/Example/PinLayoutSample/UI/Tests/TableViewExample/Cells/MethodCell.swift
@@ -47,8 +47,8 @@ class MethodCell: UITableViewCell {
         let margin: CGFloat = 10
         
         iconImageView.pin.topLeft().size(30).margin(margin)
-        nameLabel.pin.right(of: iconImageView, aligned: .center).right().marginHorizontal(margin).sizeToFit()
-        descriptionLabel.pin.below(of: [iconImageView, nameLabel]).left().right().margin(margin).sizeToFit()
+        nameLabel.pin.right(of: iconImageView, aligned: .center).right().marginHorizontal(margin).fitSize()
+        descriptionLabel.pin.below(of: [iconImageView, nameLabel]).left().right().margin(margin).fitSize()
         
         return CGSize(width: frame.width, height: descriptionLabel.frame.maxY + margin)
     }

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'synx'
 gem 'cocoapods', '~> 1.2.1'
+gem 'jazzy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,16 +45,40 @@ GEM
     colored2 (3.1.2)
     colorize (0.8.1)
     escape (0.0.4)
+    ffi (1.9.18)
     fourflusher (2.0.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.0.3)
     i18n (0.8.6)
+    jazzy (0.8.3)
+      cocoapods (~> 1.0)
+      mustache (~> 0.99)
+      open4
+      redcarpet (~> 3.2)
+      rouge (~> 1.5)
+      sass (~> 3.4)
+      sqlite3 (~> 1.3)
+      xcinvoke (~> 0.3.0)
+    liferaft (0.0.6)
     minitest (5.10.2)
     molinillo (0.5.7)
+    mustache (0.99.8)
     nanaimo (0.2.3)
     nap (1.1.0)
     netrc (0.7.8)
+    open4 (1.3.4)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    redcarpet (3.4.0)
+    rouge (1.11.1)
     ruby-macho (1.1.0)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    sqlite3 (1.3.13)
     synx (0.2.1)
       clamp (~> 0.6)
       colorize (~> 0.7)
@@ -62,6 +86,8 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
+    xcinvoke (0.3.0)
+      liferaft (~> 0.0.6)
     xcodeproj (1.5.0)
       CFPropertyList (~> 2.3.3)
       claide (>= 1.0.2, < 2.0)
@@ -73,7 +99,8 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.2.1)
+  jazzy
   synx
 
 BUNDLED WITH
-   1.13.1
+   1.13.6

--- a/PinLayout.podspec
+++ b/PinLayout.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "PinLayout"
-  s.version      = "1.2.1"
+  s.version      = "1.2.2"
   s.summary      = "Fast Swift UIViews layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable."
 
   # This description is used to generate tags and improve search results.

--- a/PinLayout.xcodeproj/project.pbxproj
+++ b/PinLayout.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		24B02B101F2A713D00C18179 /* TypesImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF11A3701E833F03008B33E5 /* TypesImpl.swift */; };
 		24BBE6351F50FA1D0091D5E9 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BBE6341F50FA1D0091D5E9 /* UnitTests.swift */; };
 		24BBE6371F50FADE0091D5E9 /* Percent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BBE6361F50FADE0091D5E9 /* Percent.swift */; };
+		24BBE6381F52EC380091D5E9 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BBE6341F50FA1D0091D5E9 /* UnitTests.swift */; };
+		24BBE6391F52EC450091D5E9 /* Percent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BBE6361F50FADE0091D5E9 /* Percent.swift */; };
 		24D18D121F350157008129EF /* UIView+LTR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D18D111F350157008129EF /* UIView+LTR.swift */; };
 		24D18D171F3B4381008129EF /* RTLSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D18D151F3B42E0008129EF /* RTLSpec.swift */; };
 		24D18D241F3E37DD008129EF /* PinLayoutGlobals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D18D231F3E37DD008129EF /* PinLayoutGlobals.swift */; };
@@ -458,6 +460,8 @@
 				24B02B091F2A713000C18179 /* PinLayout+Filters.swift in Sources */,
 				24B02B0D1F2A713D00C18179 /* PinLayoutImpl+Coordinates.swift in Sources */,
 				24B02B0A1F2A713300C18179 /* PinLayout.swift in Sources */,
+				24BBE6391F52EC450091D5E9 /* Percent.swift in Sources */,
+				24BBE6381F52EC380091D5E9 /* UnitTests.swift in Sources */,
 				24B02B0E1F2A713D00C18179 /* PinLayoutImpl+Relative.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PinLayout.xcodeproj/project.pbxproj
+++ b/PinLayout.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		24B02B0E1F2A713D00C18179 /* PinLayoutImpl+Relative.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24949A271EF550E2003643D3 /* PinLayoutImpl+Relative.swift */; };
 		24B02B0F1F2A713D00C18179 /* PinLayoutImpl+Warning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24949A2B1EF55216003643D3 /* PinLayoutImpl+Warning.swift */; };
 		24B02B101F2A713D00C18179 /* TypesImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF11A3701E833F03008B33E5 /* TypesImpl.swift */; };
+		24BBE6351F50FA1D0091D5E9 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BBE6341F50FA1D0091D5E9 /* UnitTests.swift */; };
+		24BBE6371F50FADE0091D5E9 /* Percent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BBE6361F50FADE0091D5E9 /* Percent.swift */; };
 		24D18D121F350157008129EF /* UIView+LTR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D18D111F350157008129EF /* UIView+LTR.swift */; };
 		24D18D171F3B4381008129EF /* RTLSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D18D151F3B42E0008129EF /* RTLSpec.swift */; };
 		24D18D241F3E37DD008129EF /* PinLayoutGlobals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D18D231F3E37DD008129EF /* PinLayoutGlobals.swift */; };
@@ -99,6 +101,8 @@
 		24A9782D1EE845BB002BD0F1 /* Coordinates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coordinates.swift; sourceTree = "<group>"; };
 		24A9782F1EE845CD002BD0F1 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Sources/Info.plist; sourceTree = SOURCE_ROOT; };
 		24A978301EE845CD002BD0F1 /* PinLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PinLayout.h; path = Sources/PinLayout.h; sourceTree = SOURCE_ROOT; };
+		24BBE6341F50FA1D0091D5E9 /* UnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UnitTests.swift; path = Impl/UnitTests.swift; sourceTree = "<group>"; };
+		24BBE6361F50FADE0091D5E9 /* Percent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Percent.swift; sourceTree = "<group>"; };
 		24D18D111F350157008129EF /* UIView+LTR.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+LTR.swift"; sourceTree = "<group>"; };
 		24D18D151F3B42E0008129EF /* RTLSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RTLSpec.swift; sourceTree = "<group>"; };
 		24D18D231F3E37DD008129EF /* PinLayoutGlobals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinLayoutGlobals.swift; sourceTree = "<group>"; };
@@ -173,6 +177,7 @@
 				DFC97CA61E8A8F2C001545D5 /* PinLayout.swift */,
 				24949A2D1EF69474003643D3 /* PinLayout+Filters.swift */,
 				24D18D231F3E37DD008129EF /* PinLayoutGlobals.swift */,
+				24BBE6361F50FADE0091D5E9 /* Percent.swift */,
 				DFA06B031E8B38B300B6D5E7 /* Impl */,
 				DF11A3741E834181008B33E5 /* Supporting Files */,
 			);
@@ -224,6 +229,7 @@
 				24949A2B1EF55216003643D3 /* PinLayoutImpl+Warning.swift */,
 				DF11A3701E833F03008B33E5 /* TypesImpl.swift */,
 				24D18D111F350157008129EF /* UIView+LTR.swift */,
+				24BBE6341F50FA1D0091D5E9 /* UnitTests.swift */,
 			);
 			name = Impl;
 			sourceTree = "<group>";
@@ -466,8 +472,10 @@
 				24949A2C1EF55216003643D3 /* PinLayoutImpl+Warning.swift in Sources */,
 				DFC97CA71E8A8F2C001545D5 /* PinLayout.swift in Sources */,
 				24949A2E1EF69474003643D3 /* PinLayout+Filters.swift in Sources */,
+				24BBE6351F50FA1D0091D5E9 /* UnitTests.swift in Sources */,
 				DFC97CA51E8A8EB3001545D5 /* PinLayoutImpl.swift in Sources */,
 				24A9782E1EE845BB002BD0F1 /* Coordinates.swift in Sources */,
+				24BBE6371F50FADE0091D5E9 /* Percent.swift in Sources */,
 				24949A281EF550E2003643D3 /* PinLayoutImpl+Relative.swift in Sources */,
 				24949A2A1EF551D6003643D3 /* PinLayoutImpl+Coordinates.swift in Sources */,
 			);

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ override func layoutSubviews() {
     
    logo.pin.top().left().size(100).margin(10)
    segmented.pin.right(of: logo, aligned: .top).right().marginHorizontal(10)
-   textLabel.pin.below(of: segmented, aligned: .left).right().marginTop(10).marginRight(10).sizeToFit()
+   textLabel.pin.below(of: segmented, aligned: .left).right().marginTop(10).marginRight(10).fitSize()
    separatorView.pin.below(of: [logo, textLabel], aligned: .left).right(to: segmented.edge.right).marginTop(10)
 }
 ``` 
@@ -107,11 +107,11 @@ This example shows how easily PinLayout can adjust its layout based on the view'
   let margin: CGFloat = 12
         
   if frame.width < 500 {
-      textLabel.pin.top().left().right().margin(margin).sizeToFit()
+      textLabel.pin.top().left().right().margin(margin).fitSize()
       segmentedControl.pin.below(of: textLabel).right().margin(margin)
   } else {
       segmentedControl.pin.top().right().margin(margin)
-      textLabel.pin.top().left().left(of: segmentedControl).margin(margin).sizeToFit()
+      textLabel.pin.top().left().left(of: segmentedControl).margin(margin).fitSize()
   }
 ``` 
 
@@ -733,23 +733,25 @@ Set the view’s size to match the referenced view’s size
 
 <br/>
 
-### sizeToFit()
+### fitSize()
 
 **Method:**
 
-* `sizeToFit()`  
-`sizeToFit()` is the equivalent of calling sizeThatFits(_: CGSize) once PinLayout has determined the view's width and/or height and has applied margins. **`sizeToFit()` is applied only if at least the width or the height (or both) can be determined.**
+* `fitSize()`  
+`fitSize()` is the equivalent of calling sizeThatFits(_: CGSize) once PinLayout has determined the view's size and has applied margins. **`fitSize()` is applied only if at least the width or the height (or both) can be determined.**  
+
+   The method was previously named `sizeToFit()`, but it was creating confusion with the already existing `UIView.sizeToFit()` method.
 
 ###### Usage examples:
 ```javascript
     // Adjust the label's size based on a width of 200 pixels
-    label.pin.width(200).sizeToFit()    
+    label.pin.width(200).fitSize()    
     
     // Adjust the label's size based on the computed view's width
-    label.pin.left().right().sizeToFit() 
+    label.pin.left().right().fitSize() 
     
-    // WRONG, neither the width nor the height can be determined, sizeToFit() won't be applied
-    label.pin.top().left().sizeToFit()
+    // WRONG, neither the width nor the height can be determined, fitSize() won't be applied
+    label.pin.top().left().fitSize()
 ```
 
 ###### Example:
@@ -758,7 +760,7 @@ The following example layout the UILabel on the right side of the UIImageView wi
 ![](Docs/pinlayout-sizeToFit.png)
 
 ```javascript
-	label.pin.right(of: image, aligned: .top).right().marginHorizontal(10).sizeToFit()
+	label.pin.right(of: image, aligned: .top).right().marginHorizontal(10).fitSize()
 ```
 
 
@@ -1066,14 +1068,14 @@ Warnings can be disabled also in debug mode by setting the boolean Pin.logWarnin
 ## PinLayout style guide
 
 * You should always specifies methods in the same order, it makes layout lines easier to understand. Here is our prefered ordering:  
-`view.pin.[EDGE|ANCHOR|RELATIVE].[WIDTH|HEIGHT|SIZE].[pinEdges()].[MARGINS].[sizeToFit()]`  
+`view.pin.[EDGE|ANCHOR|RELATIVE].[WIDTH|HEIGHT|SIZE].[pinEdges()].[MARGINS].[fitSize()]`  
 
-   This order reflect the logic inside PinLayout. `pinEdges()` is applied before margins and margins are applied before `sizeToFit()`.    
+   This order reflect the logic inside PinLayout. `pinEdges()` is applied before margins and margins are applied before `fitSize()`.    
 
 	```swift
 	view.pin.top().left(10%).margin(10, 12, 10, 12)
 	view.pin.left().width(100%).pinEdges().marginHorizontal(12)
-	view.pin.left().right().margin(0, 12).sizeToFit()
+	view.pin.left().right().margin(0, 12).fitSize()
 	view.pin.width(100).height(100%)
 	```
 

--- a/Sources/Coordinates.swift
+++ b/Sources/Coordinates.swift
@@ -75,7 +75,7 @@ class Coordinates {
         return CGPoint(x: view.frame.minX + view.frame.width, y: view.frame.minY + view.frame.height)
     }
 
-    fileprivate static var displayScale: CGFloat = UIScreen.main.scale
+    internal static var displayScale: CGFloat = UIScreen.main.scale
 
     static func adjustRectToDisplayScale(_ rect: CGRect) -> CGRect {
         return CGRect(x: roundFloatToDisplayScale(rect.origin.x),
@@ -91,10 +91,6 @@ class Coordinates {
     static func ceilFloatToDisplayScale(_ pointValue: CGFloat) -> CGFloat {
         return CGFloat(ceilf(Float(pointValue * displayScale))) / displayScale
     }
-}
-
-public func setUnitTest(displayScale: CGFloat) {
-    Coordinates.displayScale = displayScale
 }
 
 #endif

--- a/Sources/Impl/UnitTests.swift
+++ b/Sources/Impl/UnitTests.swift
@@ -25,50 +25,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import UIKit
+import Foundation
 
-class BasicView: UIView {
-    fileprivate let label = UILabel()
-    
-    init(text: String? = nil, color: UIColor) {
-        super.init(frame: .zero)
+public var _pinlayoutUnitTestLastWarning: String?
 
-        backgroundColor = color
-        layer.borderWidth = 1
-        layer.borderColor = UIColor.lightGray.cgColor
-        
-        label.text = text
-        label.font = .systemFont(ofSize: 7)
-        label.textColor = .white
-        label.numberOfLines = 0
-        addSubview(label)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-            
-        label.pin.topLeft().right().margin(4).fitSize()
-    }
-    
-    var sizeThatFitsExpectedArea: CGFloat = 40 * 40
-    
-    override func sizeThatFits(_ size: CGSize) -> CGSize {
-        var newSize = CGSize()
-        if size.width != CGFloat.greatestFiniteMagnitude {
-            newSize.width = size.width
-            newSize.height = sizeThatFitsExpectedArea / newSize.width
-        } else if size.height != CGFloat.greatestFiniteMagnitude {
-            newSize.height = size.height
-            newSize.width = sizeThatFitsExpectedArea / newSize.height
-        } else {
-            newSize.width = 40
-            newSize.height = sizeThatFitsExpectedArea / newSize.width
-        }
-        
-        return newSize
-    }
+public func _pinlayoutSetUnitTest(displayScale: CGFloat) {
+    Coordinates.displayScale = displayScale
 }

--- a/Sources/Percent.swift
+++ b/Sources/Percent.swift
@@ -25,50 +25,22 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import UIKit
+import Foundation
 
-class BasicView: UIView {
-    fileprivate let label = UILabel()
-    
-    init(text: String? = nil, color: UIColor) {
-        super.init(frame: .zero)
+public struct Percent {
+    let value: CGFloat
+}
 
-        backgroundColor = color
-        layer.borderWidth = 1
-        layer.borderColor = UIColor.lightGray.cgColor
-        
-        label.text = text
-        label.font = .systemFont(ofSize: 7)
-        label.textColor = .white
-        label.numberOfLines = 0
-        addSubview(label)
-    }
+postfix operator %
+public postfix func % (v: CGFloat) -> Percent {
+    return Percent(value: v)
+}
 
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-            
-        label.pin.topLeft().right().margin(4).fitSize()
-    }
-    
-    var sizeThatFitsExpectedArea: CGFloat = 40 * 40
-    
-    override func sizeThatFits(_ size: CGSize) -> CGSize {
-        var newSize = CGSize()
-        if size.width != CGFloat.greatestFiniteMagnitude {
-            newSize.width = size.width
-            newSize.height = sizeThatFitsExpectedArea / newSize.width
-        } else if size.height != CGFloat.greatestFiniteMagnitude {
-            newSize.height = size.height
-            newSize.width = sizeThatFitsExpectedArea / newSize.height
-        } else {
-            newSize.width = 40
-            newSize.height = sizeThatFitsExpectedArea / newSize.width
-        }
-        
-        return newSize
-    }
+public postfix func % (v: Int) -> Percent {
+    return Percent(value: CGFloat(v))
+}
+
+prefix operator -
+public prefix func - (p: Percent) -> Percent {
+    return Percent(value: -p.value)
 }

--- a/Sources/PinLayout.swift
+++ b/Sources/PinLayout.swift
@@ -71,7 +71,6 @@ public extension UIView {
 
 /// UIViews's anchor definition
 public protocol Anchor {
-    var point: CGPoint { get }
 }
 
 /// UIViews's list of anchors.
@@ -127,7 +126,7 @@ public protocol EdgeList {
 /// PinLayout interface
 public protocol PinLayout {
     //
-    // Layout using distances from superview’s edges
+    // MARK: Layout using distances from superview’s edges
     //
     @discardableResult func top() -> PinLayout
     @discardableResult func top(_ value: CGFloat) -> PinLayout
@@ -162,7 +161,7 @@ public protocol PinLayout {
     @discardableResult func end(_ percent: Percent) -> PinLayout
     
     //
-    // Layout using edges
+    // MARK: Layout using edges
     //
     @discardableResult func top(to edge: VerticalEdge) -> PinLayout
     @discardableResult func left(to edge: HorizontalEdge) -> PinLayout
@@ -173,7 +172,7 @@ public protocol PinLayout {
     @discardableResult func end(to edge: HorizontalEdge) -> PinLayout
 
     //
-    // Layout using anchors
+    // MARK: Layout using anchors
     //
     @discardableResult func topLeft(to anchor: Anchor) -> PinLayout
     @discardableResult func topLeft() -> PinLayout
@@ -215,7 +214,7 @@ public protocol PinLayout {
     @discardableResult func bottomEnd() -> PinLayout
 
     //
-    // Layout using relative positioning
+    // MARK: Layout using relative positioning
     //
     @discardableResult func above(of: UIView) -> PinLayout
     @discardableResult func above(of: [UIView]) -> PinLayout
@@ -248,7 +247,13 @@ public protocol PinLayout {
     @discardableResult func after(of: [UIView], aligned: VerticalAlign) -> PinLayout
 
     //
-    // Width, height and size
+    // MARK: justify / align
+    //
+    @discardableResult func justify(_: HorizontalAlign) -> PinLayout
+    @discardableResult func align(_: VerticalAlign) -> PinLayout
+    
+    //
+    // MARK: Width, height and size
     //
     @discardableResult func width(_ width: CGFloat) -> PinLayout
     @discardableResult func width(_ percent: Percent) -> PinLayout
@@ -271,13 +276,12 @@ public protocol PinLayout {
     @discardableResult func size(_ percent: Percent) -> PinLayout
     @discardableResult func size(of view: UIView) -> PinLayout
     
+    @available(*, deprecated, message: "You should now use fitSize() instead.")
     @discardableResult func sizeToFit() -> PinLayout
-    
-    @discardableResult func justify(_: HorizontalAlign) -> PinLayout
-    @discardableResult func align(_: VerticalAlign) -> PinLayout
-    
+    @discardableResult func fitSize() -> PinLayout
+
     //
-    // Margins
+    // MARK: Margins
     //
     @discardableResult func marginTop(_ value: CGFloat) -> PinLayout
     @discardableResult func marginLeft(_ value: CGFloat) -> PinLayout
@@ -357,31 +361,11 @@ public enum VerticalAlign: String {
 
 /// UIView's horizontal edges (left/right) definition
 public protocol HorizontalEdge {
-    var x: CGFloat { get }
 }
 
 /// UIView's vertical edges (top/bottom) definition
 public protocol VerticalEdge {
-    var y: CGFloat { get }
 }
 
-/// Percent
-public struct Percent {
-    let value: CGFloat
-}
-
-postfix operator %
-public postfix func % (v: CGFloat) -> Percent {
-    return Percent(value: v)
-}
-
-public postfix func % (v: Int) -> Percent {
-    return Percent(value: CGFloat(v))
-}
-
-prefix operator -
-public prefix func - (p: Percent) -> Percent {
-    return Percent(value: -p.value)
-}
         
 #endif

--- a/Sources/PinLayoutImpl+Warning.swift
+++ b/Sources/PinLayoutImpl+Warning.swift
@@ -84,7 +84,7 @@ extension PinLayoutImpl {
     
     internal func displayWarning(_ text: String) {
         print(text)
-        unitTestLastWarning = text
+        _pinlayoutUnitTestLastWarning = text
     }
     
     internal func viewDescription(_ view: UIView) -> String {

--- a/Sources/PinLayoutImpl.swift
+++ b/Sources/PinLayoutImpl.swift
@@ -30,8 +30,6 @@ import Foundation
 #if os(iOS) || os(tvOS)
 import UIKit
     
-public var unitTestLastWarning: String?
-
 class PinLayoutImpl: PinLayout {
     internal let view: UIView
 
@@ -682,7 +680,13 @@ class PinLayoutImpl: PinLayout {
         shouldSizeToFit = true
         return self
     }
-    
+
+    @discardableResult
+    func fitSize() -> PinLayout {
+        shouldSizeToFit = true
+        return self
+    }
+
     @discardableResult
     func justify(_ value: HorizontalAlign) -> PinLayout {
         justify = value

--- a/Tests/AdjustSizeSpec.swift
+++ b/Tests/AdjustSizeSpec.swift
@@ -53,11 +53,11 @@ class AdjustSizeSpec: QuickSpec {
         */
         
         beforeSuite {
-            setUnitTest(displayScale: 2)
+            _pinlayoutSetUnitTest(displayScale: 2)
         }
 
         beforeEach {
-            unitTestLastWarning = nil
+            _pinlayoutUnitTestLastWarning = nil
             
             viewController = UIViewController()
             
@@ -124,7 +124,7 @@ class AdjustSizeSpec: QuickSpec {
             it("should adjust the left but warn that the width won't be applied due to a negative width") {
                 aView.pin.left(300).right(300)
                 expect(aView.frame).to(equal(CGRect(x: 300.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["computed width (-200.0)", "greater than or equal to zero", "view will keep its current width"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["computed width (-200.0)", "greater than or equal to zero", "view will keep its current width"]))
             }
         }
         
@@ -164,7 +164,7 @@ class AdjustSizeSpec: QuickSpec {
             it("should adjust the top but warn that the height won't be applied due to a negative height") {
                 aView.pin.top(300).bottom(300)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 300.0, width: 100.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["computed height (-200.0)", "greater than or equal to zero", "view will keep its current height"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["computed height (-200.0)", "greater than or equal to zero", "view will keep its current height"]))
             }
         }
         
@@ -188,13 +188,13 @@ class AdjustSizeSpec: QuickSpec {
             it("should warn that size()'s width won't be applied") {
                 aView.pin.width(90).size(CGSize(width: 25, height: 25))
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 25.0)))
-                expect(unitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
             }
             
             it("should warn that size()'s height won't be applied") {
                 aView.pin.height(90).size(CGSize(width: 25, height: 25))
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 25.0, height: 90.0)))
-                expect(unitTestLastWarning).to(contain(["size", "height", "won't be applied", "value has already been set"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["size", "height", "won't be applied", "value has already been set"]))
             }
             
             it("should adjust the size of aView by calling a size(...) method") {
@@ -205,372 +205,372 @@ class AdjustSizeSpec: QuickSpec {
             it("should warn that size(of)'s width won't be applied") {
                 aView.pin.width(90).size(of: aViewChild)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 30.0)))
-                expect(unitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
             }
             
             it("should warn that size()'s width won't be applied") {
                 aView.pin.width(90).size(20)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 20.0)))
-                expect(unitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
             }
             
             it("should warn that size()'s width won't be applied") {
                 aView.pin.width(90).size(50%)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 200.0)))
-                expect(unitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
             }
         }
 
         //
-        // sizeToFit
+        // fitSize
         //
-        describe("the result of the sizeToFit() method") {
+        describe("the result of the fitSize() method") {
             it("should not adjust the size of aView if width or height has not been specified") {
-                aView.pin.sizeToFit()
+                aView.pin.fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 100.0, height: 60.0)))
             }
             
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.size(of: aViewChild).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.size(of: aViewChild).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 50.0, height: 30.0)))
             }
         
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.size(CGSize(width: 20, height: 100)).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.size(CGSize(width: 20, height: 100)).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 20.0, height: 80.0)))
             }
             
-            it("should adjust the size and position the view by calling center(), height() and sizeToFit()") {
-                aViewChild.pin.center(to: aView.anchor.center).height(40).sizeToFit()
+            it("should adjust the size and position the view by calling center(), height() and fitSize()") {
+                aViewChild.pin.center(to: aView.anchor.center).height(40).fitSize()
                 expect(aViewChild.frame).to(equal(CGRect(x: 30.0, y: 10.0, width: 40.0, height: 40.0)))
             }
             
-            it("should adjust the size and position the view by calling center(), width() and sizeToFit()") {
-                aViewChild.pin.center(to: aView.anchor.center).width(20).sizeToFit()
+            it("should adjust the size and position the view by calling center(), width() and fitSize()") {
+                aViewChild.pin.center(to: aView.anchor.center).width(20).fitSize()
                 expect(aViewChild.frame).to(equal(CGRect(x: 40.0, y: -10.0, width: 20.0, height: 80.0)))
             }
         }
         
-        describe("the result of the sizeToFit() method when pinning left and right edges") {
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.left(20).right(80).sizeToFit()
+        describe("the result of the fitSize() method when pinning left and right edges") {
+            it("should adjust the size with fitSize()") {
+                aView.pin.left(20).right(80).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 20.0, y: 100.0, width: 300.0, height: 5.5)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.left(20).right(80).marginLeft(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.left(20).right(80).marginLeft(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 100.0, width: 290.0, height: 6)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.left(20).right(80).marginRight(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.left(20).right(80).marginRight(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 20.0, y: 100.0, width: 290.0, height: 6.0)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.left(20).right(80).marginLeft(10).marginRight(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.left(20).right(80).marginLeft(10).marginRight(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 100.0, width: 280.0, height: 6.0)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.left(20).right(80).marginLeft(10).marginRight(10).sizeToFit().justify(.center)
+            it("should adjust the size with fitSize()") {
+                aView.pin.left(20).right(80).marginLeft(10).marginRight(10).fitSize().justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 100.0, width: 280.0, height: 6.0)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.left(20).right(80).marginLeft(10).marginRight(10).sizeToFit().justify(.right)
+            it("should adjust the size with fitSize()") {
+                aView.pin.left(20).right(80).marginLeft(10).marginRight(10).fitSize().justify(.right)
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 100.0, width: 280.0, height: 6.0)))
             }
         }
         
-        describe("the result of the sizeToFit() method when pinning top and bottom edges") {
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).bottom(80).sizeToFit()
+        describe("the result of the fitSize() method when pinning top and bottom edges") {
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).bottom(80).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 20.0, width: 5.5, height: 300)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).bottom(80).marginTop(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).bottom(80).marginTop(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 30.0, width: 6, height: 290)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).bottom(80).marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).bottom(80).marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 20.0, width: 6, height: 290)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).bottom(80).marginTop(10).marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).bottom(80).marginTop(10).marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 30.0, width: 6, height: 280)))
             }
         }
         
         
-        describe("the result of the sizeToFit() method when pinning right edge + width") {
-            it("should adjust the size with sizeToFit() and distribute extra width") {
-                aView.pin.right(100).width(200).sizeToFit()
+        describe("the result of the fitSize() method when pinning right edge + width") {
+            it("should adjust the size with fitSize() and distribute extra width") {
+                aView.pin.right(100).width(200).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 100.0, y: 100.0, width: 200, height: 8)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra width") {
-                aView.pin.right(100).width(200).marginLeft(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra width") {
+                aView.pin.right(100).width(200).marginLeft(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 100.0, y: 100.0, width: 200, height: 8)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra width") {
-                aView.pin.right(100).width(200).marginRight(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra width") {
+                aView.pin.right(100).width(200).marginRight(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 90.0, y: 100.0, width: 200, height: 8)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra width") {
-                aView.pin.right(100).width(200).marginLeft(10).marginRight(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra width") {
+                aView.pin.right(100).width(200).marginLeft(10).marginRight(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 90.0, y: 100.0, width: 200, height: 8)))
             }
         }
         
-        describe("the result of the sizeToFit() method when pinning right edge + width + pinEdges()") {
-            it("should adjust the size with sizeToFit() and distribute extra width") {
-                aView.pin.right(100).width(200).pinEdges().sizeToFit()
+        describe("the result of the fitSize() method when pinning right edge + width + pinEdges()") {
+            it("should adjust the size with fitSize() and distribute extra width") {
+                aView.pin.right(100).width(200).pinEdges().fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 100.0, y: 100.0, width: 200, height: 8)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra width") {
-                aView.pin.right(100).width(200).pinEdges().marginLeft(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra width") {
+                aView.pin.right(100).width(200).pinEdges().marginLeft(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 110.0, y: 100.0, width: 190, height: 8.5)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra width") {
-                aView.pin.right(100).width(200).pinEdges().marginRight(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra width") {
+                aView.pin.right(100).width(200).pinEdges().marginRight(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 100.0, y: 100.0, width: 190, height: 8.5)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra width") {
-                aView.pin.right(100).width(200).pinEdges().marginLeft(10).marginRight(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra width") {
+                aView.pin.right(100).width(200).pinEdges().marginLeft(10).marginRight(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 110.0, y: 100.0, width: 180, height: 9)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra width") {
-                aView.pin.right(100).width(200).pinEdges().marginLeft(10).marginRight(10).sizeToFit().justify(.left)
+            it("should adjust the size with fitSize() and distribute extra width") {
+                aView.pin.right(100).width(200).pinEdges().marginLeft(10).marginRight(10).fitSize().justify(.left)
                 expect(aView.frame).to(equal(CGRect(x: 110.0, y: 100.0, width: 180, height: 9)))
             }
 
-            it("should adjust the size with sizeToFit() and distribute extra width") {
-                aView.pin.bottom(100).height(200).pinEdges().marginTop(10).marginBottom(10).sizeToFit().justify(.left)
+            it("should adjust the size with fitSize() and distribute extra width") {
+                aView.pin.bottom(100).height(200).pinEdges().marginTop(10).marginBottom(10).fitSize().justify(.left)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 110.0, width: 9, height: 180)))
             }
         }
 
-        describe("the result of the sizeToFit() method when pinning bottom edge + height") {
-            it("should adjust the size with sizeToFit() and distribute extra height") {
-                aView.pin.bottom(100).height(200).sizeToFit()
+        describe("the result of the fitSize() method when pinning bottom edge + height") {
+            it("should adjust the size with fitSize() and distribute extra height") {
+                aView.pin.bottom(100).height(200).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 8, height: 200)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra height") {
-                aView.pin.bottom(100).height(200).marginTop(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra height") {
+                aView.pin.bottom(100).height(200).marginTop(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 8, height: 200)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra height") {
-                aView.pin.bottom(100).height(200).marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra height") {
+                aView.pin.bottom(100).height(200).marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 90.0, width: 8, height: 200)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra height") {
-                aView.pin.bottom(100).height(200).marginTop(10).marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra height") {
+                aView.pin.bottom(100).height(200).marginTop(10).marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 90.0, width: 8, height: 200)))
             }
         }
         
-        describe("the result of the sizeToFit() method when pinning bottom edge + height + pinEdges()") {
-            it("should adjust the size with sizeToFit() and distribute extra height") {
-                aView.pin.bottom(100).height(200).pinEdges().sizeToFit()
+        describe("the result of the fitSize() method when pinning bottom edge + height + pinEdges()") {
+            it("should adjust the size with fitSize() and distribute extra height") {
+                aView.pin.bottom(100).height(200).pinEdges().fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 8, height: 200)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra height") {
-                aView.pin.bottom(100).height(200).pinEdges().marginTop(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra height") {
+                aView.pin.bottom(100).height(200).pinEdges().marginTop(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 110.0, width: 8.5, height: 190)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra height") {
-                aView.pin.bottom(100).height(200).pinEdges().marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra height") {
+                aView.pin.bottom(100).height(200).pinEdges().marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 8.5, height: 190)))
             }
             
-            it("should adjust the size with sizeToFit() and distribute extra height") {
-                aView.pin.bottom(100).height(200).pinEdges().marginTop(10).marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize() and distribute extra height") {
+                aView.pin.bottom(100).height(200).pinEdges().marginTop(10).marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 110.0, width: 9, height: 180)))
             }
         }
         
-        describe("the result of the sizeToFit() method when pinning top, left, bottom and right edges") {
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).sizeToFit()
+        describe("the result of the fitSize() method when pinning top, left, bottom and right edges") {
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 20.0, y: 20.0, width: 200.0, height: 8)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 20.0, width: 190.0, height: 8.5)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginRight(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginRight(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 20.0, y: 20.0, width: 190.0, height: 8.5)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 20.0, width: 180.0, height: 9.0)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginTop(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginTop(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 20.0, y: 30.0, width: 200.0, height: 8)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 20.0, y: 20.0, width: 200.0, height: 8.0)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 20.0, width: 190.0, height: 8.5)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginTop(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginTop(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 30.0, width: 190.0, height: 8.5)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 20.0, width: 190.0, height: 8.5)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginTop(10).marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginTop(10).marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 30.0, width: 190.0, height: 8.5)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 30.0, width: 180.0, height: 9)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 20.0, width: 180.0, height: 9.0)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).marginBottom(10).sizeToFit()
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).marginBottom(10).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 30.0, width: 180.0, height: 9.0)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).sizeToFit().justify(.left)
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).fitSize().justify(.left)
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 30.0, width: 180.0, height: 9)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).sizeToFit().justify(.center)
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).fitSize().justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 30.0, width: 180.0, height: 9)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(15).marginRight(5).marginTop(10).sizeToFit().justify(.right)
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(15).marginRight(5).marginTop(10).fitSize().justify(.right)
                 expect(aView.frame).to(equal(CGRect(x: 35.0, y: 30.0, width: 180.0, height: 9)))
             }
 
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).sizeToFit().align(.top)
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).fitSize().align(.top)
                 expect(aView.frame).to(equal(CGRect(x: 30.0, y: 30.0, width: 180.0, height: 9)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).sizeToFit().align(.center)
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(180).right(180).marginLeft(10).marginRight(10).marginTop(10).fitSize().align(.center)
                 expect(aView.frame).to(beCloseTo(CGRect(x: 30.0, y: 120.5, width: 180.0, height: 9.0), within: 0.5))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).left(20).bottom(80).right(180).marginLeft(15).marginRight(5).marginTop(10).sizeToFit().align(.bottom)
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).left(20).bottom(80).right(180).marginLeft(15).marginRight(5).marginTop(10).fitSize().align(.bottom)
                 expect(aView.frame).to(equal(CGRect(x: 35.0, y: 311.0, width: 180.0, height: 9.0)))
             }
             
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).bottom(80).marginTop(10).marginBottom(10).sizeToFit().align(.center)
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).bottom(80).marginTop(10).marginBottom(10).fitSize().align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 30.0, width: 6.0, height: 280.0)))
             }
             
-            it("should adjust the size with sizeToFit()") {
-                aView.pin.top(20).bottom(80).marginTop(10).marginBottom(10).sizeToFit().align(.bottom)
+            it("should adjust the size with fitSize()") {
+                aView.pin.top(20).bottom(80).marginTop(10).marginBottom(10).fitSize().align(.bottom)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 30.0, width: 6.0, height: 280.0)))
             }
         }
         
-        describe("the result of the sizeToFit(...) methods") {
+        describe("the result of the fitSize(...) methods") {
             
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.width(100).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.width(100).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 100.0, height: 16.0)))
             }
             
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.height(100).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.height(100).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 16.0, height: 100.0)))
             }
             
-            it("should adjust the size of aView by calling sizeToFit()") {
-                aView.pin.top(0).height(70).width(100).sizeToFit()
+            it("should adjust the size of aView by calling fitSize()") {
+                aView.pin.top(0).height(70).width(100).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 0.0, width: 100.0, height: 16.0)))
             }
 
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.width(100).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.width(100).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 100.0, height: 16.0)))
             }
             
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.height(90).width(100).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.height(90).width(100).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 100.0, height: 16.0)))
             }
             
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.width(of: aViewChild).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.width(of: aViewChild).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 50.0, height: 32.0)))
             }
             
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.width(80).width(of: aViewChild).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.width(80).width(of: aViewChild).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 80.0, height: 20.0)))
             }
 
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.height(100).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.height(100).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 16.0, height: 100.0)))
             }
             
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.height(of: aViewChild).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.height(of: aViewChild).fitSize()
                 expect(aView.frame).to(beCloseTo(CGRect(x: 140.0, y: 100.0, width: 53.3333333333333, height: 30.0), within: 0.4))
             }
             
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.width(90).height(of: aViewChild).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.width(90).height(of: aViewChild).fitSize()
                 expect(aView.frame).to(beCloseTo(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 17.6), within: 0.4))
             }
             
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.size(of: aViewChild).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.size(of: aViewChild).fitSize()
                 expect(aView.frame).to(beCloseTo(CGRect(x: 140.0, y: 100.0, width: 50.0, height: 30.0)))
             }
             
-            it("should adjust the size of aView by calling sizeToFit() method") {
-                aView.pin.width(90).size(of: aViewChild).sizeToFit()
+            it("should adjust the size of aView by calling fitSize() method") {
+                aView.pin.width(90).size(of: aViewChild).fitSize()
                 expect(aView.frame).to(beCloseTo(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 17.6), within: 0.4))
             }
         }

--- a/Tests/JustifyAlignSpec.swift
+++ b/Tests/JustifyAlignSpec.swift
@@ -42,11 +42,11 @@ class JustifyAlignSpec: QuickSpec {
         */
         
         beforeSuite {
-            setUnitTest(displayScale: 2)
+            _pinlayoutSetUnitTest(displayScale: 2)
         }
 
         beforeEach {
-            unitTestLastWarning = nil
+            _pinlayoutUnitTestLastWarning = nil
             
             viewController = UIViewController()
             
@@ -67,31 +67,31 @@ class JustifyAlignSpec: QuickSpec {
             it("test when missing left and right coordinate") {
                 aView.pin.justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
             }
             
             it("test when missing left and right coordinate") {
                 aView.pin.width(100).justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
             }
             
             it("test when missing left and right coordinate") {
                 aView.pin.left().pinEdges().justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
             }
             
             it("test when missing right coordinate") {
                 aView.pin.left().width(250).justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
             }
             
             it("test when hCenter has been set") {
                 aView.pin.hCenter(60).justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 10.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["justify", "center", "won't be applied", "hCenter"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify", "center", "won't be applied", "hCenter"]))
             }
         }
         
@@ -102,31 +102,31 @@ class JustifyAlignSpec: QuickSpec {
             it("test when missing top and bottom coordinate") {
                 aView.pin.align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
             }
             
             it("test when missing left and right coordinate") {
                 aView.pin.width(100).align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
             }
             
             it("test when missing left and right coordinate") {
                 aView.pin.left().pinEdges().align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
             }
             
             it("test when missing right coordinate") {
                 aView.pin.left().width(250).align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
             }
             
             it("test when hCenter has been set") {
                 aView.pin.hCenter(60).align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 10.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
             }
         }
         

--- a/Tests/MinMaxWidthHeightSpec.swift
+++ b/Tests/MinMaxWidthHeightSpec.swift
@@ -42,11 +42,11 @@ class MinMaxWidthHeightSpec: QuickSpec {
         */
         
         beforeSuite {
-            setUnitTest(displayScale: 2)
+            _pinlayoutSetUnitTest(displayScale: 2)
         }
 
         beforeEach {
-            unitTestLastWarning = nil
+            _pinlayoutUnitTestLastWarning = nil
             
             viewController = UIViewController()
             
@@ -130,7 +130,7 @@ class MinMaxWidthHeightSpec: QuickSpec {
             it("should adjust the width when using hCenter") {
                 aView.pin.hCenter().width(20).minWidth(250).justify(.left)
                 expect(aView.frame).to(equal(CGRect(x: 75.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["justify(.left)", "won't be applied", "justification is not applied when hCenter has been set"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify(.left)", "won't be applied", "justification is not applied when hCenter has been set"]))
             }
         }
         
@@ -211,25 +211,25 @@ class MinMaxWidthHeightSpec: QuickSpec {
             it("should adjust the width using justify") {
                 aView.pin.left().width(100%).maxWidth(250).justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["justify(.center)", "won't be applied", "left and right coordinates"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify(.center)", "won't be applied", "left and right coordinates"]))
             }
             
             it("should adjust the width using justify") {
                 aView.pin.left().width(100%).maxWidth(250).justify(.right)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["justify(.right)", "won't be applied", "left and right coordinates"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify(.right)", "won't be applied", "left and right coordinates"]))
             }
             
             it("should adjust the width using justify") {
                 aView.pin.right().width(100%).maxWidth(250).justify(.left)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["justify(.left)", "won't be applied", "left and right coordinates"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify(.left)", "won't be applied", "left and right coordinates"]))
             }
             
             it("should adjust the width using justify") {
                 aView.pin.right().width(100%).maxWidth(250).justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["justify(.center)", "won't be applied", "left and right coordinates"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify(.center)", "won't be applied", "left and right coordinates"]))
             }
             
             it("should adjust the width using justify") {
@@ -269,52 +269,52 @@ class MinMaxWidthHeightSpec: QuickSpec {
         }
         
         //
-        // minWidth/maxWidth & sizeToFit()
+        // minWidth/maxWidth & fitSize()
         //
-        describe("the result of the minWidth/maxWidth & sizeToFit()") {
-            it("should adjust the width when using sizeToFit") {
+        describe("the result of the minWidth/maxWidth & fitSize()") {
+            it("should adjust the width when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.left().width(100%).maxWidth(250).sizeToFit()
+                aView.pin.left().width(100%).maxWidth(250).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 250.0, height: 6.5)))
             }
             
-            it("should adjust the width when using sizeToFit") {
+            it("should adjust the width when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.left().width(100%).maxWidth(250).sizeToFit().justify(.left)
+                aView.pin.left().width(100%).maxWidth(250).fitSize().justify(.left)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 250.0, height: 6.5)))
             }
             
-            it("should adjust the width when using sizeToFit") {
+            it("should adjust the width when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.left().right().width(100%).maxWidth(250).sizeToFit().justify(.right)
+                aView.pin.left().right().width(100%).maxWidth(250).fitSize().justify(.right)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 250.0, height: 6.5)))
             }
             
-            it("should adjust the width when using sizeToFit") {
+            it("should adjust the width when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.left().right().maxWidth(250).sizeToFit().justify(.center)
+                aView.pin.left().right().maxWidth(250).fitSize().justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 75.0, y: 100.0, width: 250.0, height: 6.5)))
             }
                 
-            it("should adjust the width when using sizeToFit") {
+            it("should adjust the width when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.left().width(10).minWidth(250).sizeToFit()
+                aView.pin.left().width(10).minWidth(250).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 250.0, height: 6.5)))
             }
             
-            it("should adjust the width when using sizeToFit") {
+            it("should adjust the width when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.left().right().width(10).minWidth(250).sizeToFit().justify(.center)
+                aView.pin.left().right().width(10).minWidth(250).fitSize().justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 75.0, y: 100.0, width: 250.0, height: 6.5)))
             }
             
-            it("should adjust the width when using sizeToFit") {
+            it("should adjust the width when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.left().right().width(10).minWidth(250).marginLeft(10).sizeToFit().justify(.center)
+                aView.pin.left().right().width(10).minWidth(250).marginLeft(10).fitSize().justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 80.0, y: 100.0, width: 250.0, height: 6.5)))
             }
             
-            it("should adjust the width when using sizeToFit") {
+            it("should adjust the width when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
                 aView.pin.left().right().width(250).marginLeft(10).justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 80.0, y: 100.0, width: 250.0, height: 60)))
@@ -393,7 +393,7 @@ class MinMaxWidthHeightSpec: QuickSpec {
             it("should adjust the height when using hCenter") {
                 aView.pin.vCenter().height(20).minHeight(250).align(.top)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 75.0, width: 100.0, height: 250.0)))
-                expect(unitTestLastWarning).to(contain(["align(.top)", "won't be applied", "alignment is not applied when vCenter has been set"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.top)", "won't be applied", "alignment is not applied when vCenter has been set"]))
             }
         }
         
@@ -469,37 +469,37 @@ class MinMaxWidthHeightSpec: QuickSpec {
             it("should adjust the height using align") {
                 aView.pin.top().height(100%).maxHeight(250).align(.top)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 00.0, width: 100.0, height: 250.0)))
-                expect(unitTestLastWarning).to(contain(["align(.top)", "won't be applied", "top and bottom coordinates"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.top)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {
                 aView.pin.top().height(100%).maxHeight(250).align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 0.0, width: 100.0, height: 250.0)))
-                expect(unitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom coordinates"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {
                 aView.pin.top().height(100%).maxHeight(250).align(.bottom)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 00.0, width: 100.0, height: 250.0)))
-                expect(unitTestLastWarning).to(contain(["align(.bottom)", "won't be applied", "top and bottom coordinates"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.bottom)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {
                 aView.pin.bottom().height(100%).maxHeight(250).align(.top)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 150.0, width: 100.0, height: 250.0)))
-                expect(unitTestLastWarning).to(contain(["align(.top)", "won't be applied", "top and bottom coordinates"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.top)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {
                 aView.pin.bottom().height(100%).maxHeight(250).align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 150.0, width: 100.0, height: 250.0)))
-                expect(unitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom coordinates"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {
                 aView.pin.bottom().height(100%).maxHeight(250).align(.bottom)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 150.0, width: 100.0, height: 250.0)))
-                expect(unitTestLastWarning).to(contain(["align(.bottom)", "won't be applied", "top and bottom coordinates"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.bottom)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {
@@ -534,52 +534,52 @@ class MinMaxWidthHeightSpec: QuickSpec {
         }
 
         //
-        // minHeight/maxHeight & sizeToFit()
+        // minHeight/maxHeight & fitSize()
         //
-        describe("the result of the minHeight/maxWidth & sizeToFit()") {
-            it("should adjust the height when using sizeToFit") {
+        describe("the result of the minHeight/maxWidth & fitSize()") {
+            it("should adjust the height when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.top().height(100%).maxHeight(200).sizeToFit()
+                aView.pin.top().height(100%).maxHeight(200).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 0.0, width: 8.0, height: 200.0)))
             }
 
-            it("should adjust the height when using sizeToFit") {
+            it("should adjust the height when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.top().height(100%).maxHeight(200).sizeToFit().align(.top)
+                aView.pin.top().height(100%).maxHeight(200).fitSize().align(.top)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 0.0, width: 8.0, height: 200.0)))
             }
 
-            it("should adjust the height when using sizeToFit") {
+            it("should adjust the height when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.top().bottom().height(100%).maxHeight(200).sizeToFit().align(.bottom)
+                aView.pin.top().bottom().height(100%).maxHeight(200).fitSize().align(.bottom)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 200.0, width: 8.0, height: 200.0)))
             }
 
-            it("should adjust the height when using sizeToFit") {
+            it("should adjust the height when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.top().bottom().maxHeight(200).sizeToFit().align(.center)
+                aView.pin.top().bottom().maxHeight(200).fitSize().align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 8.0, height: 200.0)))
             }
 
-            it("should adjust the height when using sizeToFit") {
+            it("should adjust the height when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.top().height(10).minHeight(200).sizeToFit()
+                aView.pin.top().height(10).minHeight(200).fitSize()
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 0.0, width: 8.0, height: 200.0)))
             }
 
-            it("should adjust the height when using sizeToFit") {
+            it("should adjust the height when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.top().bottom().height(10).minHeight(200).sizeToFit().align(.center)
+                aView.pin.top().bottom().height(10).minHeight(200).fitSize().align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 8.0, height: 200.0)))
             }
 
-            it("should adjust the height when using sizeToFit") {
+            it("should adjust the height when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
-                aView.pin.top().bottom().height(10).minHeight(200).marginTop(10).sizeToFit().align(.center)
+                aView.pin.top().bottom().height(10).minHeight(200).marginTop(10).fitSize().align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 105.0, width: 8.0, height: 200.0)))
             }
 
-            it("should adjust the height when using sizeToFit") {
+            it("should adjust the height when using fitSize") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
                 aView.pin.top().bottom().height(200).marginTop(10).align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 105.0, width: 100.0, height: 200.0)))

--- a/Tests/PinEdgesSpec.swift
+++ b/Tests/PinEdgesSpec.swift
@@ -45,7 +45,7 @@ class PinEdgesSpec: QuickSpec {
         */
 
         beforeEach {
-            unitTestLastWarning = nil
+            _pinlayoutUnitTestLastWarning = nil
         
             viewController = UIViewController()
             
@@ -336,7 +336,7 @@ class PinEdgesSpec: QuickSpec {
             it("should not apply hCenter") {
                 aView.pin.left().hCenter(-20)
                 expect(aView.frame).to(equal(CGRect(x: 0, y: 100.0, width: 200.0, height: 100.0)))
-                expect(unitTestLastWarning).to(contain(["hCenter", "won't be applied", "left"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["hCenter", "won't be applied", "left"]))
             }
             
             it("should warns that the view is not added to any view") {
@@ -387,7 +387,7 @@ class PinEdgesSpec: QuickSpec {
             it("should adjust the aView") {
                 aView.pin.top().vCenter(-20)
                 expect(aView.frame).to(equal(CGRect(x: 140, y: 0.0, width: 200.0, height: 100.0)))
-                expect(unitTestLastWarning).to(contain(["vCenter", "won't be applied", "top"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["vCenter", "won't be applied", "top"]))
             }
             
             it("should warns that the view is not added to any view") {
@@ -395,7 +395,7 @@ class PinEdgesSpec: QuickSpec {
                 unAttachedView.pin.vCenter(20%)
                 
                 expect(unAttachedView.frame).to(equal(CGRect(x: 10, y: 10, width: 200.0, height: 10)))
-                expect(unitTestLastWarning).to(contain(["vCenter", "won't be applied", "view must be added"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["vCenter", "won't be applied", "view must be added"]))
             }
             
             it("should adjust the aView") {
@@ -411,7 +411,7 @@ class PinEdgesSpec: QuickSpec {
             it("should adjust the aView") {
                 aView.pin.top().vCenter(-20%)
                 expect(aView.frame).to(equal(CGRect(x: 140, y: 0.0, width: 200.0, height: 100.0)))
-                expect(unitTestLastWarning).to(contain(["vCenter", "won't be applied", "top"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["vCenter", "won't be applied", "top"]))
             }
         }
     }

--- a/Tests/RTLSpec.swift
+++ b/Tests/RTLSpec.swift
@@ -47,7 +47,7 @@ class RTLSpec: QuickSpec {
         */
 
         beforeEach {
-            unitTestLastWarning = nil
+            _pinlayoutUnitTestLastWarning = nil
             Pin.layoutDirection(.ltr)
             
             viewController = UIViewController()
@@ -71,50 +71,50 @@ class RTLSpec: QuickSpec {
         describe("warn") {
             it("should display a warning") {
                 aView.pin.start(10).left(20)
-                expect(unitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
             }
             
             it("should display a warning") {
                 aView.pin.end(10).right(20)
-                expect(unitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
             }
 
             it("should display a warning") {
                 Pin.layoutDirection(.auto)
                 aView.pin.start(10).left(20)
-                expect(unitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
             }
             
             it("should display a warning") {
                 Pin.layoutDirection(.auto)
                 aView.pin.end(10).right(20)
-                expect(unitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
             }
             
             it("should display a warning") {
                 Pin.layoutDirection(.ltr)
                 aView.pin.start(10).left(20)
-                expect(unitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
             }
             
             it("should display a warning") {
                 Pin.layoutDirection(.ltr)
                 aView.pin.end(10).right(20)
-                expect(unitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
             }
 
             it("should display a warning") {
                 // With RTL
                 Pin.layoutDirection(.rtl)
                 aView.pin.start(10).right(20)
-                expect(unitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
             }
             
             it("should display a warning") {
                 // With RTL
                 Pin.layoutDirection(.rtl)
                 aView.pin.end(10).left(20)
-                expect(unitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
             }
         }
         

--- a/Tests/RelativePositionMultipleViewsSpec.swift
+++ b/Tests/RelativePositionMultipleViewsSpec.swift
@@ -54,7 +54,7 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
         */
 
         beforeEach {
-            unitTestLastWarning = nil
+            _pinlayoutUnitTestLastWarning = nil
             
             viewController = UIViewController()
             
@@ -87,21 +87,21 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
                 let unatachedView = UIView()
                 bViewChild.pin.above(of: unatachedView)
                 expect(bViewChild.frame).to(equal(CGRect(x: 40, y: 10, width: 60, height: 20)))
-                expect(unitTestLastWarning).to(contain(["above", "won't be applied", "no valid references"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["above", "won't be applied", "no valid references"]))
             }
             
             it("should warns the view bottom edge") {
                 let unatachedView = UIView()
                 bViewChild.pin.above(of: [aView, unatachedView])
                 expect(bViewChild.frame).to(equal(CGRect(x: 40.0, y: -40.0, width: 60.0, height: 20.0)))
-                expect(unitTestLastWarning).to(contain(["above", "won't be applied", "the reference view", "must be added", "as a reference"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["above", "won't be applied", "the reference view", "must be added", "as a reference"]))
             }
             
             it("Should warn, but the view should be anyway layout it above") {
                 let unatachedView = UIView()
                 bViewChild.pin.above(of: [aView, unatachedView])
                 expect(bViewChild.frame).to(equal(CGRect(x: 40.0, y: -40.0, width: 60.0, height: 20.0)))
-                expect(unitTestLastWarning).to(contain(["above", "won't be applied", "the reference view", "must be added", "as a reference"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["above", "won't be applied", "the reference view", "must be added", "as a reference"]))
             }
         }
         

--- a/Tests/WarningSpec.swift
+++ b/Tests/WarningSpec.swift
@@ -42,11 +42,11 @@ class WarningSpec: QuickSpec {
         */
         
         beforeSuite {
-            setUnitTest(displayScale: 2)
+            _pinlayoutSetUnitTest(displayScale: 2)
         }
 
         beforeEach {
-            unitTestLastWarning = nil
+            _pinlayoutUnitTestLastWarning = nil
             
             viewController = UIViewController()
             
@@ -67,13 +67,13 @@ class WarningSpec: QuickSpec {
             it("test when left & right & width is set") {
                 aView.pin.left().right().width(100%).pinEdges()
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 400.0, height: 60.0)))
-                expect(unitTestLastWarning).to(contain(["pinEdges()", "won't be applied", "horizontally"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["pinEdges()", "won't be applied", "horizontally"]))
             }
             
             it("test when top & bottom & height is set") {
                 aView.pin.top().bottom().height(100%).pinEdges()
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 0.0, width: 100.0, height: 400.0)))
-                expect(unitTestLastWarning).to(contain(["pinEdges()", "won't be applied", "vertically"]))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["pinEdges()", "won't be applied", "vertically"]))
             }
         }
     }


### PR DESCRIPTION
Renamed the method `sizeThatFit()` to `fitSize().
Its name was creating confusion with the already existing `UIView.sizeToFit()` method.  

Plus: 
* Moved few unit test related property/method in a new UnitTest.swift file. 
* Start supporting jazzy documentation.


