### PR TITLE
Warning now display more context information

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,6 +3,7 @@ use_frameworks!
 workspace 'PinLayout.xcworkspace'
 
 target 'PinLayoutTests' do
+  platform :ios, "8.0"
   project 'PinLayout.xcodeproj'
 
   pod 'Quick'
@@ -10,6 +11,7 @@ target 'PinLayoutTests' do
 end
 
 target 'PinLayoutSample' do
+  platform :ios, "8.0"
   project 'Example/PinLayoutSample.xcodeproj'
 
   # Debug only

--- a/Sources/Impl/UnitTests.swift
+++ b/Sources/Impl/UnitTests.swift
@@ -25,7 +25,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import Foundation
+import UIKit
 
 public var _pinlayoutUnitTestLastWarning: String?
 

--- a/Sources/Percent.swift
+++ b/Sources/Percent.swift
@@ -25,7 +25,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import Foundation
+import UIKit
 
 public struct Percent {
     let value: CGFloat

--- a/Sources/PinLayoutImpl+Warning.swift
+++ b/Sources/PinLayoutImpl+Warning.swift
@@ -40,19 +40,19 @@ extension PinLayoutImpl {
     
     internal func warnPropertyAlreadySet(_ propertyName: String, propertyValue: CGFloat, _ context: Context) {
         guard Pin.logWarnings else { return }
-        displayWarning("PinLayout Conflict: \(context()) won't be applied since it value has already been set to \(propertyValue).\n")
+        displayWarning("PinLayout Conflict: \(context()) won't be applied since it value has already been set to \(propertyValue).")
     }
     
     internal func warnPropertyAlreadySet(_ propertyName: String, propertyValue: CGSize, _ context: Context) {
         guard Pin.logWarnings else { return }
-        displayWarning("PinLayout Conflict: \(context()) won't be applied since it value has already been set to CGSize(width: \(propertyValue.width), height: \(propertyValue.height)).\n")
+        displayWarning("PinLayout Conflict: \(context()) won't be applied since it value has already been set to CGSize(width: \(propertyValue.width), height: \(propertyValue.height)).")
     }
     
     internal func warnConflict(_ context: Context, _ properties: [String: CGFloat]) {
         guard Pin.logWarnings else { return }
-        var warning = "PinLayout Conflict: \(context()) won't be applied since it conflicts with the following already set properties:\n"
+        var warning = "PinLayout Conflict: \(context()) won't be applied since it conflicts with the following already set properties:"
         properties.forEach { (property) in
-            warning += " \(property.key): \(property.value)\n"
+            warning += "\n \(property.key): \(property.value)"
         }
         
         displayWarning(warning)
@@ -61,7 +61,7 @@ extension PinLayoutImpl {
     internal func displayLayoutWarnings() {
         if let justify = justify {
             func context() -> String { return "justify(.\(justify))" }
-            if !((_left != nil && _right != nil) || (shouldPinEdges && _width != nil && (_left != nil || _right != nil || _hCenter != nil))) {
+            if !((_left != nil && _right != nil) || (shouldPinEdges && width != nil && (_left != nil || _right != nil || _hCenter != nil))) {
                 warn("the left and right coordinates must be set to justify the view horizontally.", context)
             }
             
@@ -72,7 +72,7 @@ extension PinLayoutImpl {
         
         if let align = align {
             func context() -> String { return "align(.\(align))" }
-            if !((_top != nil && _bottom != nil) || (shouldPinEdges && _height != nil && (_top != nil || _bottom != nil || _vCenter != nil))) {
+            if !((_top != nil && _bottom != nil) || (shouldPinEdges && height != nil && (_top != nil || _bottom != nil || _vCenter != nil))) {
                 warn("the top and bottom coordinates must be set to align the view vertically.", context)
             }
             

--- a/Sources/PinLayoutImpl+Warning.swift
+++ b/Sources/PinLayoutImpl+Warning.swift
@@ -30,27 +30,27 @@ extension PinLayoutImpl {
     
     internal func warn(_ text: String, _ context: Context) {
         guard Pin.logWarnings else { return }
-        warn("\(context()) won't be applied, \(text)\n")
+        warn("\(context()) won't be applied, \(text)")
     }
     
     internal func warn(_ text: String) {
         guard Pin.logWarnings else { return }
-        displayWarning("\n👉 PinLayout Warning: \(text)\n")
+        displayWarning("PinLayout Warning: \(text)")
     }
     
     internal func warnPropertyAlreadySet(_ propertyName: String, propertyValue: CGFloat, _ context: Context) {
         guard Pin.logWarnings else { return }
-        displayWarning("\n👉 PinLayout Conflict: \(context()) won't be applied since it value has already been set to \(propertyValue).\n")
+        displayWarning("PinLayout Conflict: \(context()) won't be applied since it value has already been set to \(propertyValue).\n")
     }
     
     internal func warnPropertyAlreadySet(_ propertyName: String, propertyValue: CGSize, _ context: Context) {
         guard Pin.logWarnings else { return }
-        displayWarning("\n👉 PinLayout Conflict: \(context()) won't be applied since it value has already been set to CGSize(width: \(propertyValue.width), height: \(propertyValue.height)).\n")
+        displayWarning("PinLayout Conflict: \(context()) won't be applied since it value has already been set to CGSize(width: \(propertyValue.width), height: \(propertyValue.height)).\n")
     }
     
     internal func warnConflict(_ context: Context, _ properties: [String: CGFloat]) {
         guard Pin.logWarnings else { return }
-        var warning = "\n👉 PinLayout Conflict: \(context()) won't be applied since it conflicts with the following already set properties:\n"
+        var warning = "PinLayout Conflict: \(context()) won't be applied since it conflicts with the following already set properties:\n"
         properties.forEach { (property) in
             warning += " \(property.key): \(property.value)\n"
         }
@@ -61,7 +61,7 @@ extension PinLayoutImpl {
     internal func displayLayoutWarnings() {
         if let justify = justify {
             func context() -> String { return "justify(.\(justify))" }
-            if !((_left != nil && _right != nil) || (shouldPinEdges && width != nil && (_left != nil || _right != nil || _hCenter != nil))) {
+            if !((_left != nil && _right != nil) || (shouldPinEdges && _width != nil && (_left != nil || _right != nil || _hCenter != nil))) {
                 warn("the left and right coordinates must be set to justify the view horizontally.", context)
             }
             
@@ -72,7 +72,7 @@ extension PinLayoutImpl {
         
         if let align = align {
             func context() -> String { return "align(.\(align))" }
-            if !((_top != nil && _bottom != nil) || (shouldPinEdges && height != nil && (_top != nil || _bottom != nil || _vCenter != nil))) {
+            if !((_top != nil && _bottom != nil) || (shouldPinEdges && _height != nil && (_top != nil || _bottom != nil || _vCenter != nil))) {
                 warn("the top and bottom coordinates must be set to align the view vertically.", context)
             }
             
@@ -83,7 +83,24 @@ extension PinLayoutImpl {
     }
     
     internal func displayWarning(_ text: String) {
-        print(text)
+        var displayText = "\n👉 \(text)"
+        
+        let viewType = "\(type(of: view))"
+        displayText += "\n   (View type: \(viewType), Frame: \(view.frame)"
+        
+        var currentView = view
+        var hierarchy: [String] = []
+        while let parent = currentView.superview {
+            hierarchy.insert("\(type(of: parent))", at: 0)
+            currentView = parent
+        }
+        if hierarchy.count > 0 {
+            displayText += ", Superviews: \(hierarchy.flatMap({ $0 }).joined(separator: " -> "))"
+        }
+        
+        displayText += ", Tag: \(view.tag))\n"
+        
+        print(displayText)
         _pinlayoutUnitTestLastWarning = text
     }
     

--- a/Sources/PinLayoutImpl+Warning.swift
+++ b/Sources/PinLayoutImpl+Warning.swift
@@ -15,17 +15,17 @@ extension PinLayoutImpl {
     
     internal func relativeEdgeContext(method: String, edge: VerticalEdge) -> String {
         let edge = edge as! VerticalEdgeImpl
-        return "\(method)(to: \(edge.type.rawValue), of: \(edge.view))"
+        return "\(method)(to: .\(edge.type.rawValue), of: \(viewDescription(edge.view)))"
     }
     
     internal func relativeEdgeContext(method: String, edge: HorizontalEdge) -> String {
         let edge = edge as! HorizontalEdgeImpl
-        return "\(method)(to: \(edge.type.rawValue), of: \(edge.view))"
+        return "\(method)(to: .\(edge.type.rawValue), of: \(viewDescription(edge.view))"
     }
     
     internal func relativeAnchorContext(method: String, anchor: Anchor) -> String {
         let anchor = anchor as! AnchorImpl
-        return "\(method)(to: \(anchor.type.rawValue), of: \(anchor.view))"
+        return "\(method)(to: .\(anchor.type.rawValue), of: \(viewDescription(anchor.view)))"
     }
     
     internal func warn(_ text: String, _ context: Context) {
@@ -84,9 +84,7 @@ extension PinLayoutImpl {
     
     internal func displayWarning(_ text: String) {
         var displayText = "\n👉 \(text)"
-        
-        let viewType = "\(type(of: view))"
-        displayText += "\n   (View type: \(viewType), Frame: \(view.frame)"
+        displayText += "\n   (Layouted view info: Type: \(viewName(view)), Frame: \(view.frame)"
         
         var currentView = view
         var hierarchy: [String] = []
@@ -105,7 +103,11 @@ extension PinLayoutImpl {
     }
     
     internal func viewDescription(_ view: UIView) -> String {
-        return "\"\(view.description)\""
+        return "(\(viewName(view)), Frame: \(view.frame))"
+    }
+    
+    internal func viewName(_ view: UIView) -> String {
+        return "\(type(of: view))"
     }
 }
 

--- a/Sources/PinLayoutImpl.swift
+++ b/Sources/PinLayoutImpl.swift
@@ -914,10 +914,12 @@ extension PinLayoutImpl {
 
     fileprivate func handlePinEdges() {
         guard shouldPinEdges else { return }
-        if let width = applyMinMax(toWidth: width) {
-            if _left != nil && _right != nil {
-                warn("pinEdges() won't be applied horizontally, left and right coordinates are already set.")
-            } else if let left = _left {
+        guard _top == nil || _bottom == nil || _left == nil || _right == nil else {
+            return warn("pinEdges() won't be applied, top, left, bottom and right coordinates are already set.")
+        }
+        
+        if let width = applyMinMax(toWidth: width), _left == nil || _right == nil  {
+            if let left = _left {
                 // convert the width into a right
                 assert(self._right == nil)
                 self._right = left + width
@@ -938,10 +940,8 @@ extension PinLayoutImpl {
             }
         }
 
-        if let height = applyMinMax(toHeight: height) {
-            if _top != nil && _bottom != nil {
-                warn("pinEdges() won't be applied vertically, top and bottom coordinates are already set.")
-            } else if let top = _top {
+        if let height = applyMinMax(toHeight: height), _top == nil || _bottom == nil {
+            if let top = _top {
                 // convert the height into a bottom
                 assert(self._bottom == nil)
                 self._bottom = top + height

--- a/Sources/PinLayoutImpl.swift
+++ b/Sources/PinLayoutImpl.swift
@@ -576,7 +576,7 @@ class PinLayoutImpl: PinLayout {
 
     @discardableResult
     func width(of view: UIView) -> PinLayout {
-        return setWidth(view.frame.width, { return "width(of: \(view))" })
+        return setWidth(view.frame.width, { return "width(of: \(viewDescription(view)))" })
     }
     
     @discardableResult
@@ -619,7 +619,7 @@ class PinLayoutImpl: PinLayout {
 
     @discardableResult
     func height(of view: UIView) -> PinLayout {
-        return setHeight(view.frame.height, { return "height(of: \(view))" })
+        return setHeight(view.frame.height, { return "height(of: \(viewDescription(view)))" })
     }
     
     @discardableResult
@@ -671,7 +671,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func size(of view: UIView) -> PinLayout {
-        func context() -> String { return "size(of \(view))" }
+        func context() -> String { return "size(of \(viewDescription(view)))" }
         return setSize(view.frame.size, context)
     }
     
@@ -799,7 +799,7 @@ extension PinLayoutImpl {
         if let superview = view.superview {
             return superview
         } else {
-            warn("the view must be added as a sub-view before being layouted using this method.", context)
+            warn("the view (\(viewName(view))) must be added as a sub-view before being layouted using this method.", context)
             return nil
         }
     }
@@ -808,7 +808,7 @@ extension PinLayoutImpl {
         if let superview = referenceView.superview {
             return superview
         } else {
-            warn("the reference view \(viewDescription(referenceView)) is invalid. UIViews must be added as a sub-view before being used as a reference.", context)
+            warn("the reference view (\(viewName(referenceView))) is invalid. UIViews must be added as a sub-view before being used as a reference.", context)
             return nil
         }
     }

--- a/Sources/PinLayoutImpl.swift
+++ b/Sources/PinLayoutImpl.swift
@@ -799,7 +799,7 @@ extension PinLayoutImpl {
         if let superview = view.superview {
             return superview
         } else {
-            warn("the view (\(viewName(view))) must be added as a sub-view before being layouted using this method.", context)
+            warn("the view must be added as a sub-view before being layouted using this method.", context)
             return nil
         }
     }
@@ -808,7 +808,7 @@ extension PinLayoutImpl {
         if let superview = referenceView.superview {
             return superview
         } else {
-            warn("the reference view (\(viewName(referenceView))) is invalid. UIViews must be added as a sub-view before being used as a reference.", context)
+            warn("the reference view \(viewDescription(referenceView)) must be added as a sub-view before being used as a reference.", context)
             return nil
         }
     }

--- a/Tests/WarningSpec.swift
+++ b/Tests/WarningSpec.swift
@@ -64,16 +64,10 @@ class WarningSpec: QuickSpec {
         // pinEdges warnings
         //
         describe("pinEdges() should warn ") {
-            it("test when left & right & width is set") {
-                aView.pin.left().right().width(100%).pinEdges()
-                expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 400.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["pinEdges()", "won't be applied", "horizontally"]))
-            }
-            
-            it("test when top & bottom & height is set") {
-                aView.pin.top().bottom().height(100%).pinEdges()
-                expect(aView.frame).to(equal(CGRect(x: 40.0, y: 0.0, width: 100.0, height: 400.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["pinEdges()", "won't be applied", "vertically"]))
+            it("test when top, left, bottom and right is set") {
+                aView.pin.top().bottom().left().right().width(100%).pinEdges()
+                expect(aView.frame).to(equal(CGRect(x: 0.0, y: 0.0, width: 400.0, height: 400.0)))
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["pinEdges()", "won't be applied", "top, left, bottom and right coordinates are already set"]))
             }
         }
     }


### PR DESCRIPTION
Warning now display more context information

* The class name of the view being layouted.
* The view's current frame
* The class name of all superviews
* The view's Tag

Ex: 
👉  PinLayout Warning: width(50.0%) won't be applied, the view (UIView) must be added as a sub-view before being layouted using this method.
   (Layouted view info: Type: UIView, Frame: (10.0, 10.0, 20.0, 30.0), Tag: 0)

👉 PinLayout Warning: width(-20.0) won't be applied, the width (-20.0) must be greater than or equal to zero.
(Layouted view info: Type: ItemButton, Frame: (140.0, 100.0, 100.0, 60.0), Superviews: HomeView -> UIView, Tag: 0)

👉  PinLayout Warning: topLeft(to: .topLeft, of: (UIView, Frame: (10.0, 10.0, 10.0, 10.0))) won't be applied, the reference view (UIView, Frame: (10.0, 10.0, 10.0, 10.0)) must be added as a sub-view before being used as a reference.
   (Layouted view info: Type: UIView, Frame: (140.0, 100.0, 100.0, 60.0), Superviews: UIView -> UIView, Tag: 0)