### PR TITLE
Examples now support iOS 11 and iPhone X landscape mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9
 
 env:
   matrix:
+    - SCHEME=PinLayout       SDK=iphonesimulator11.0
     - SCHEME=PinLayout       SDK=iphonesimulator10.3
-    - SCHEME=PinLayoutSample SDK=iphonesimulator10.3
-    - SCHEME=PinLayoutTVOS   SDK=appletvsimulator10.2 
+    - SCHEME=PinLayoutSample SDK=iphonesimulator11.0
+    - SCHEME=PinLayoutTVOS   SDK=appletvsimulator11.0 
 
 before_install:
 #  - brew outdated xctool || brew upgrade xctool;

--- a/Example/PinLayoutSample.xcodeproj/project.pbxproj
+++ b/Example/PinLayoutSample.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		246813001F8D013500462E53 /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246812FF1F8D013500462E53 /* TodayViewController.swift */; };
 		246813031F8D013500462E53 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 246813011F8D013500462E53 /* MainInterface.storyboard */; };
 		246813071F8D013500462E53 /* PinLayoutTodayExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 246812FB1F8D013500462E53 /* PinLayoutTodayExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		247157941F87BD680003424F /* UIEdgeInsets+PinLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247157931F87BD680003424F /* UIEdgeInsets+PinLayout.swift */; };
 		249326891EEEEE3D00BCB814 /* Stylesheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249326881EEEEE3D00BCB814 /* Stylesheet.swift */; };
 		2493268C1EEEEFF100BCB814 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2493268B1EEEEFF100BCB814 /* BaseViewController.swift */; };
 		2493268E1EEEF02700BCB814 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2493268D1EEEF02700BCB814 /* BaseView.swift */; };
@@ -128,6 +129,7 @@
 		246812FF1F8D013500462E53 /* TodayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewController.swift; sourceTree = "<group>"; };
 		246813021F8D013500462E53 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
 		246813041F8D013500462E53 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		247157931F87BD680003424F /* UIEdgeInsets+PinLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIEdgeInsets+PinLayout.swift"; sourceTree = "<group>"; };
 		249326881EEEEE3D00BCB814 /* Stylesheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stylesheet.swift; sourceTree = "<group>"; };
 		2493268B1EEEEFF100BCB814 /* BaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		2493268D1EEEF02700BCB814 /* BaseView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 				2493268B1EEEEFF100BCB814 /* BaseViewController.swift */,
 				2439CC381E665C6B003326FB /* BasicView.swift */,
 				249326881EEEEE3D00BCB814 /* Stylesheet.swift */,
+				247157931F87BD680003424F /* UIEdgeInsets+PinLayout.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -628,6 +631,7 @@
 				241637741F8E4BC200EE703A /* IntroObjectiveCViewController.m in Sources */,
 				2439CC541E665C6B003326FB /* RelativeView.swift in Sources */,
 				2439CC551E665C6B003326FB /* RelativeViewController.swift in Sources */,
+				247157941F87BD680003424F /* UIEdgeInsets+PinLayout.swift in Sources */,
 				24D18D1E1F3DED0D008129EF /* IntroRTLViewController.swift in Sources */,
 				24A9C2031EF16A3E00F2CF64 /* AutoAdjustingSizeView.swift in Sources */,
 				24D18D1D1F3DED0D008129EF /* IntroRTLView.swift in Sources */,

--- a/Example/PinLayoutSample/UI/Common/BaseFormView.swift
+++ b/Example/PinLayoutSample/UI/Common/BaseFormView.swift
@@ -46,7 +46,7 @@ class BaseFormView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        formScrollView.pin.topLeft().bottomRight()
+        formScrollView.pin.top().left().bottom().right().margin(containerInsets())
     }
     
     override func didChangeLayoutGuides() {
@@ -79,5 +79,13 @@ class BaseFormView: BaseView {
     fileprivate func setFormScrollView(bottomInset: CGFloat) {
         formScrollView.contentInset = UIEdgeInsets(top: formScrollView.contentInset.top, left: 0,
                                                    bottom: bottomInset, right: 0)
+    }
+    
+    fileprivate func containerInsets() -> UIEdgeInsets {
+        if #available(iOS 11.0, *) {
+            return safeAreaInsets
+        } else {
+            return UIEdgeInsets.zero
+        }
     }
 }

--- a/Example/PinLayoutSample/UI/Common/BaseFormView.swift
+++ b/Example/PinLayoutSample/UI/Common/BaseFormView.swift
@@ -46,12 +46,12 @@ class BaseFormView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        formScrollView.pin.top().left().bottom().right().margin(containerInsets())
+        formScrollView.pin.top().left().bottom().right().margin(safeArea)
     }
     
-    override func didChangeLayoutGuides() {
-        super.didChangeLayoutGuides()
-        formScrollView.contentOffset = CGPoint(x: 0, y: topLayoutGuide)
+    override func safeAreaDidChange() {
+        super.safeAreaDidChange()
+        formScrollView.contentOffset = CGPoint(x: 0, y: safeArea.top)
     }
     
     @objc
@@ -79,13 +79,5 @@ class BaseFormView: BaseView {
     fileprivate func setFormScrollView(bottomInset: CGFloat) {
         formScrollView.contentInset = UIEdgeInsets(top: formScrollView.contentInset.top, left: 0,
                                                    bottom: bottomInset, right: 0)
-    }
-    
-    fileprivate func containerInsets() -> UIEdgeInsets {
-        if #available(iOS 11.0, *) {
-            return safeAreaInsets
-        } else {
-            return UIEdgeInsets.zero
-        }
     }
 }

--- a/Example/PinLayoutSample/UI/Common/BaseView.swift
+++ b/Example/PinLayoutSample/UI/Common/BaseView.swift
@@ -20,8 +20,18 @@
 import UIKit
 
 class BaseView: UIView {
-    fileprivate (set) var topLayoutGuide: CGFloat = 0
-    fileprivate (set) var bottomLayoutGuide: CGFloat = 0
+    private var legacySafeArea: UIEdgeInsets = .zero
+    
+    // safeArea returns UIView.safeAreaInsets for iOS 11+ or
+    // an UIEdgeInsets initialized with the UIViewController's topLayoutGuide and
+    // bottomLayoutGuide for other iOS versions.
+    var safeArea: UIEdgeInsets {
+        if #available(iOS 11.0, *) {
+            return safeAreaInsets
+        } else {
+            return legacySafeArea
+        }
+    }
     
     init() {
         super.init(frame: .zero)
@@ -32,25 +42,17 @@ class BaseView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func setLayoutGuides(top: CGFloat, bottom: CGFloat) {
-        var didChange = false
-        
-        if top != topLayoutGuide {
-            topLayoutGuide = top
-            didChange = true
-        }
-        
-        if bottom != bottomLayoutGuide {
-            bottomLayoutGuide = bottom
-            didChange = true
-        }
-        
-        if didChange {
-            didChangeLayoutGuides()
-        }
+    func setSafeArea(_ safeArea: UIEdgeInsets) {
+        guard safeArea != self.safeArea else { return }
+        legacySafeArea = safeArea
+        safeAreaDidChange()
     }
     
-    func didChangeLayoutGuides() {
+    func safeAreaDidChange() {
         setNeedsLayout()
+    }
+    
+    override func safeAreaInsetsDidChange() {
+        safeAreaDidChange()
     }
 }

--- a/Example/PinLayoutSample/UI/Common/BaseViewController.swift
+++ b/Example/PinLayoutSample/UI/Common/BaseViewController.swift
@@ -20,12 +20,12 @@
 import UIKit
 
 class BaseViewController: UIViewController {
-    
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         
-        if let view = view as? BaseView {
-            view.setLayoutGuides(top: topLayoutGuide.length, bottom: bottomLayoutGuide.length)
+        if #available(iOS 11.0, *) {
+        } else if let view = view as? BaseView {
+            view.setSafeArea(UIEdgeInsets(top: topLayoutGuide.length, left: 0, bottom: bottomLayoutGuide.length, right: 0))
         }
     }
 }

--- a/Example/PinLayoutSample/UI/Common/BasicView.swift
+++ b/Example/PinLayoutSample/UI/Common/BasicView.swift
@@ -43,7 +43,7 @@ class BasicView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
             
-        label.pin.topLeft().right().margin(4).fitSize()
+        label.pin.top().left().right().margin(4).fitSize()
     }
     
     var sizeThatFitsExpectedArea: CGFloat = 40 * 40

--- a/Example/PinLayoutSample/UI/Common/UIEdgeInsets+PinLayout.swift
+++ b/Example/PinLayoutSample/UI/Common/UIEdgeInsets+PinLayout.swift
@@ -1,0 +1,33 @@
+//
+//  UIEdgeInsets+PinLayout.swift
+//  PinLayoutSample
+//
+//  Created by DION, Luc (MTL) on 2017-10-06.
+//  Copyright © 2017 Mirego. All rights reserved.
+//
+
+import UIKit
+
+extension UIEdgeInsets {
+    func insetBy(dx: CGFloat, dy: CGFloat) -> UIEdgeInsets {
+        return UIEdgeInsets(top: self.top + dy, left: self.left + dx, bottom: self.bottom + dy, right: self.right + dx)
+    }
+    
+    func minInsets(_ insets: UIEdgeInsets) -> UIEdgeInsets {
+        return UIEdgeInsets(top: minValue(self.top, minValue: insets.top),
+                            left: minValue(self.left, minValue: insets.left),
+                            bottom: minValue(self.bottom, minValue: insets.bottom),
+                            right: minValue(self.right, minValue: insets.right))
+    }
+    
+    func minInsets(dx: CGFloat, dy: CGFloat) -> UIEdgeInsets {
+        return UIEdgeInsets(top: minValue(self.top, minValue: dy),
+                            left: minValue(self.left, minValue: dx),
+                            bottom: minValue(self.bottom, minValue: dy),
+                            right: minValue(self.right, minValue: dx))
+    }
+    
+    fileprivate func minValue(_ value: CGFloat, minValue: CGFloat) -> CGFloat {
+        return value >= minValue ? value : minValue
+    }
+}

--- a/Example/PinLayoutSample/UI/Examples/AdjustToContainer/AdjustToContainerView.swift
+++ b/Example/PinLayoutSample/UI/Examples/AdjustToContainer/AdjustToContainerView.swift
@@ -21,7 +21,7 @@ import UIKit
 import PinLayout
 
 class AdjustToContainerView: BaseView {
-    fileprivate let container = UIView()
+    fileprivate let contentView = UIView()
     fileprivate let languageSelectorView = ChoiceSelectorView(text: "What is your favorite language?", choices: ["Swift", "Objective-C", "C++"])
     fileprivate let swiftOpinionSelectorView = ChoiceSelectorView(text: "Overall, are you satisfied with the Swift performance in your projects?", choices: ["Yes", "No"])
     fileprivate let swiftUsageSelectorView = ChoiceSelectorView(text: "How often do you typically use Swift?", choices: ["Daily", "Weekly", "Montly", "Do not use"])
@@ -29,11 +29,11 @@ class AdjustToContainerView: BaseView {
     override init() {
         super.init()
 
-        addSubview(container)
+        addSubview(contentView)
 
-        container.addSubview(languageSelectorView)
-        container.addSubview(swiftOpinionSelectorView)
-        container.addSubview(swiftUsageSelectorView)
+        contentView.addSubview(languageSelectorView)
+        contentView.addSubview(swiftOpinionSelectorView)
+        contentView.addSubview(swiftUsageSelectorView)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -43,18 +43,11 @@ class AdjustToContainerView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        container.pin.top().bottom().left().right().margin(containerInsets())
+        // Layout the contentView using the view's safeArea.
+        contentView.pin.top().bottom().left().right().margin(safeArea)
         
         languageSelectorView.pin.top().left().right().fitSize()
         swiftOpinionSelectorView.pin.below(of: languageSelectorView, aligned: .left).right().marginTop(10).fitSize()
         swiftUsageSelectorView.pin.below(of: swiftOpinionSelectorView, aligned: .left).right().marginTop(10).fitSize()
-    }
-    
-    fileprivate func containerInsets() -> UIEdgeInsets {
-        if #available(iOS 11.0, *) {
-            return safeAreaInsets
-        } else {
-            return UIEdgeInsets(top: topLayoutGuide, left: 0, bottom: 0, right: 0)
-        }
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/AdjustToContainer/AdjustToContainerView.swift
+++ b/Example/PinLayoutSample/UI/Examples/AdjustToContainer/AdjustToContainerView.swift
@@ -21,7 +21,7 @@ import UIKit
 import PinLayout
 
 class AdjustToContainerView: BaseView {
-
+    fileprivate let container = UIView()
     fileprivate let languageSelectorView = ChoiceSelectorView(text: "What is your favorite language?", choices: ["Swift", "Objective-C", "C++"])
     fileprivate let swiftOpinionSelectorView = ChoiceSelectorView(text: "Overall, are you satisfied with the Swift performance in your projects?", choices: ["Yes", "No"])
     fileprivate let swiftUsageSelectorView = ChoiceSelectorView(text: "How often do you typically use Swift?", choices: ["Daily", "Weekly", "Montly", "Do not use"])
@@ -29,9 +29,11 @@ class AdjustToContainerView: BaseView {
     override init() {
         super.init()
 
-        addSubview(languageSelectorView)
-        addSubview(swiftOpinionSelectorView)
-        addSubview(swiftUsageSelectorView)
+        addSubview(container)
+
+        container.addSubview(languageSelectorView)
+        container.addSubview(swiftOpinionSelectorView)
+        container.addSubview(swiftUsageSelectorView)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -41,8 +43,18 @@ class AdjustToContainerView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        languageSelectorView.pin.top(topLayoutGuide).left().right().fitSize()
+        container.pin.top().bottom().left().right().margin(containerInsets())
+        
+        languageSelectorView.pin.top().left().right().fitSize()
         swiftOpinionSelectorView.pin.below(of: languageSelectorView, aligned: .left).right().marginTop(10).fitSize()
         swiftUsageSelectorView.pin.below(of: swiftOpinionSelectorView, aligned: .left).right().marginTop(10).fitSize()
+    }
+    
+    fileprivate func containerInsets() -> UIEdgeInsets {
+        if #available(iOS 11.0, *) {
+            return safeAreaInsets
+        } else {
+            return UIEdgeInsets(top: topLayoutGuide, left: 0, bottom: 0, right: 0)
+        }
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/AdjustToContainer/Subviews/ChoiceSelectorView.swift
+++ b/Example/PinLayoutSample/UI/Examples/AdjustToContainer/Subviews/ChoiceSelectorView.swift
@@ -46,15 +46,18 @@ class ChoiceSelectorView: UIView {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        _ = layout(size: frame.size)
+        _ = layout()
     }
     
     override func sizeThatFits(_ size: CGSize) -> CGSize {
-        return layout(size: size)
+        // 1) Set the width to the specified width
+        self.pin.width(size.width)
+        
+        // 2) Layout the contentView's controls
+        return layout()
     }
     
-    fileprivate func layout(size: CGSize) -> CGSize {
-        let width = size.width
+    fileprivate func layout() -> CGSize {
         let margin: CGFloat = 12
         
         if frame.width > 500 {
@@ -67,6 +70,6 @@ class ChoiceSelectorView: UIView {
             segmentedControl.pin.below(of: textLabel).right().margin(margin)
         }
         
-        return CGSize(width: width, height: max(textLabel.frame.maxY, segmentedControl.frame.maxY) + margin)
+        return CGSize(width: frame.width, height: max(textLabel.frame.maxY, segmentedControl.frame.maxY) + margin)
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/AdjustToContainer/Subviews/ChoiceSelectorView.swift
+++ b/Example/PinLayoutSample/UI/Examples/AdjustToContainer/Subviews/ChoiceSelectorView.swift
@@ -59,7 +59,7 @@ class ChoiceSelectorView: UIView {
         
         if frame.width > 500 {
             // The UISegmentedControl is at the top-right corner and the label takes the remaining horizontal space.
-            segmentedControl.pin.topRight().margin(margin)
+            segmentedControl.pin.top().right().margin(margin)
             textLabel.pin.top().left().left(of: segmentedControl).margin(margin).fitSize()
         } else {
             // The UISegmentedControl is placed below the label.

--- a/Example/PinLayoutSample/UI/Examples/AutoAdjustingSizeView/AutoAdjustingSizeView.swift
+++ b/Example/PinLayoutSample/UI/Examples/AutoAdjustingSizeView/AutoAdjustingSizeView.swift
@@ -74,7 +74,7 @@ class AutoAdjustingSizeView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        contentScrollView.pin.topLeft().bottomRight()
+        contentScrollView.pin.top().bottom().left().right().margin(containerInsets())
         
         row1.pin.top().left().right().height(40)
         row1Item1.pin.top().left().bottom().width(50).margin(2)
@@ -82,18 +82,26 @@ class AutoAdjustingSizeView: BaseView {
 
         row2.pin.below(of: row1, aligned: .left).size(of: row1).marginTop(10)
         row2Item1.pin.top().right().bottom().width(150).width(25%).margin(2)
-        row2Item2.pin.left(of: row2Item1, aligned: .top).bottomLeft().margin(0, 2, 2, 2)
+        row2Item2.pin.left(of: row2Item1, aligned: .top).left().bottom().margin(0, 2, 2, 2)
 
         row3.pin.below(of: row2, aligned: .left).size(of: row1).marginTop(10)
         row3Item1.pin.topCenter().width(50).bottom().margin(2)
-        row3Item2.pin.left(of: row3Item1, aligned: .top).bottomLeft().margin(0, 2, 2, 2)
-        row3Item3.pin.right(of: row3Item1, aligned: .top).bottomRight().margin(0, 2, 2, 2)
+        row3Item2.pin.left(of: row3Item1, aligned: .top).left().bottom().margin(0, 2, 2, 2)
+        row3Item3.pin.right(of: row3Item1, aligned: .top).right().bottom().margin(0, 2, 2, 2)
 
         row4.pin.below(of: row3, aligned: .left).size(of: row1).marginTop(10)
         row4Item1.pin.top().left().width(25%).bottom().margin(2)
         row4Item2.pin.right(of: row4Item1, aligned: .top).width(50%).bottom().margin(0, 2, 2, 2)
-        row4Item3.pin.right(of: row4Item2, aligned: .top).bottomRight().margin(0, 2, 2, 2)
+        row4Item3.pin.right(of: row4Item2, aligned: .top).right().bottom().margin(0, 2, 2, 2)
         
-        contentScrollView.contentSize = CGSize(width: frame.width, height: row4.frame.maxY)
+        contentScrollView.contentSize = CGSize(width: contentScrollView.frame.width, height: row4.frame.maxY)
+    }
+    
+    fileprivate func containerInsets() -> UIEdgeInsets {
+        if #available(iOS 11.0, *) {
+            return safeAreaInsets
+        } else {
+            return UIEdgeInsets.zero
+        }
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/AutoAdjustingSizeView/AutoAdjustingSizeView.swift
+++ b/Example/PinLayoutSample/UI/Examples/AutoAdjustingSizeView/AutoAdjustingSizeView.swift
@@ -74,7 +74,8 @@ class AutoAdjustingSizeView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        contentScrollView.pin.top().bottom().left().right().margin(containerInsets())
+        // Layout the contentScrollView using the view's safeArea.
+        contentScrollView.pin.top().bottom().left().right().margin(safeArea)
         
         row1.pin.top().left().right().height(40)
         row1Item1.pin.top().left().bottom().width(50).margin(2)
@@ -95,13 +96,5 @@ class AutoAdjustingSizeView: BaseView {
         row4Item3.pin.right(of: row4Item2, aligned: .top).right().bottom().margin(0, 2, 2, 2)
         
         contentScrollView.contentSize = CGSize(width: contentScrollView.frame.width, height: row4.frame.maxY)
-    }
-    
-    fileprivate func containerInsets() -> UIEdgeInsets {
-        if #available(iOS 11.0, *) {
-            return safeAreaInsets
-        } else {
-            return UIEdgeInsets.zero
-        }
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/Form/FormView.swift
+++ b/Example/PinLayoutSample/UI/Examples/Form/FormView.swift
@@ -81,9 +81,8 @@ class FormView: BaseFormView {
     
     fileprivate func layoutFormFields() {
         let margin: CGFloat = 12
-        let width = max(300, frame.width)
         
-        formContainerView.pin.topCenter().width(width).pinEdges().margin(margin, margin, margin)
+        formContainerView.pin.top().hCenter().width(100%).maxWidth(400).pinEdges().margin(margin, margin, margin)
         
         formTitleLabel.pin.topCenter().margin(margin)
 

--- a/Example/PinLayoutSample/UI/Examples/Form/FormView.swift
+++ b/Example/PinLayoutSample/UI/Examples/Form/FormView.swift
@@ -82,6 +82,7 @@ class FormView: BaseFormView {
     fileprivate func layoutFormFields() {
         let margin: CGFloat = 12
         
+        // Layout the formContainerView using the view's safeArea.
         formContainerView.pin.top().hCenter().width(100%).maxWidth(400).pinEdges().margin(margin, margin, margin)
         
         formTitleLabel.pin.topCenter().margin(margin)

--- a/Example/PinLayoutSample/UI/Examples/Intro/IntroView.swift
+++ b/Example/PinLayoutSample/UI/Examples/Intro/IntroView.swift
@@ -30,23 +30,25 @@ class IntroView: BaseView {
     
     override init() {
         super.init()
+        
+        addSubview(container)
 
         logo.contentMode = .scaleAspectFit
-        addSubview(logo)
+        container.addSubview(logo)
         
         segmented.selectedSegmentIndex = 0
         segmented.tintColor = .pinLayoutColor
-        addSubview(segmented)
+        container.addSubview(segmented)
         
         textLabel.text = "Swift manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable.\n\nSwift manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable."
         textLabel.font = .systemFont(ofSize: 14)
         textLabel.numberOfLines = 0
         textLabel.lineBreakMode = .byWordWrapping
-        addSubview(textLabel)
+        container.addSubview(textLabel)
         
         separatorView.pin.height(1)
         separatorView.backgroundColor = .pinLayoutColor
-        addSubview(separatorView)
+        container.addSubview(separatorView)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -56,9 +58,20 @@ class IntroView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        logo.pin.top().left().size(100).margin(topLayoutGuide + 10, 10, 10)
-        segmented.pin.right(of: logo, aligned: .top).right().marginHorizontal(10)
+        container.pin.top().bottom().left().right().margin(containerInsets())
+        
+        logo.pin.top().left().size(100).aspectRatio().marginTop(10)
+        segmented.pin.right(of: logo, aligned: .top).right().marginLeft(10)
         textLabel.pin.below(of: segmented, aligned: .left).width(of: segmented).pinEdges().marginTop(10).fitSize()
         separatorView.pin.below(of: [logo, textLabel], aligned: .left).right(to: segmented.edge.right).marginTop(10)
+    }
+    
+    fileprivate func containerInsets() -> UIEdgeInsets {
+        if #available(iOS 11.0, *) {
+            // The container margin must be at least of 10 pixels all around
+            return safeAreaInsets.minInsets(UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10))
+        } else {
+            return UIEdgeInsets(top: topLayoutGuide, left: 10, bottom: 0, right: 10)
+        }
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/Intro/IntroView.swift
+++ b/Example/PinLayoutSample/UI/Examples/Intro/IntroView.swift
@@ -22,7 +22,7 @@ import PinLayout
 
 class IntroView: BaseView {
 
-    fileprivate let container = UIView()
+    fileprivate let contentView = UIView()
     fileprivate let logo = UIImageView(image: UIImage(named: "PinLayout-logo"))
     fileprivate let segmented = UISegmentedControl(items: ["Intro", "1", "2"])
     fileprivate let textLabel = UILabel()
@@ -31,24 +31,24 @@ class IntroView: BaseView {
     override init() {
         super.init()
         
-        addSubview(container)
+        addSubview(contentView)
 
         logo.contentMode = .scaleAspectFit
-        container.addSubview(logo)
+        contentView.addSubview(logo)
         
         segmented.selectedSegmentIndex = 0
         segmented.tintColor = .pinLayoutColor
-        container.addSubview(segmented)
+        contentView.addSubview(segmented)
         
         textLabel.text = "Swift manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable.\n\nSwift manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable."
         textLabel.font = .systemFont(ofSize: 14)
         textLabel.numberOfLines = 0
         textLabel.lineBreakMode = .byWordWrapping
-        container.addSubview(textLabel)
+        contentView.addSubview(textLabel)
         
         separatorView.pin.height(1)
         separatorView.backgroundColor = .pinLayoutColor
-        container.addSubview(separatorView)
+        contentView.addSubview(separatorView)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -58,20 +58,13 @@ class IntroView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        container.pin.top().bottom().left().right().margin(containerInsets())
+        // Layout the contentView using the view's safeArea with at least of 10 pixels all around.
+        let containerInsets = safeArea.minInsets(UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10))
+        contentView.pin.top().bottom().start().end().margin(containerInsets)
         
         logo.pin.top().left().size(100).aspectRatio().marginTop(10)
         segmented.pin.right(of: logo, aligned: .top).right().marginLeft(10)
         textLabel.pin.below(of: segmented, aligned: .left).width(of: segmented).pinEdges().marginTop(10).fitSize()
         separatorView.pin.below(of: [logo, textLabel], aligned: .left).right(to: segmented.edge.right).marginTop(10)
-    }
-    
-    fileprivate func containerInsets() -> UIEdgeInsets {
-        if #available(iOS 11.0, *) {
-            // The container margin must be at least of 10 pixels all around
-            return safeAreaInsets.minInsets(UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10))
-        } else {
-            return UIEdgeInsets(top: topLayoutGuide, left: 10, bottom: 0, right: 10)
-        }
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/IntroRTL/IntroRTLView.swift
+++ b/Example/PinLayoutSample/UI/Examples/IntroRTL/IntroRTLView.swift
@@ -22,7 +22,7 @@ import PinLayout
 
 class IntroRTLView: BaseView {
 
-    fileprivate let container = UIView()
+    fileprivate let contentView = UIView()
     fileprivate let logo = UIImageView(image: UIImage(named: "PinLayout-logo"))
     fileprivate let segmented = UISegmentedControl(items: ["Intro", "1", "2"])
     fileprivate let textLabel = UILabel()
@@ -36,24 +36,24 @@ class IntroRTLView: BaseView {
         // `UIApplication.shared.userInterfaceLayoutDirection` (< iOS 9)
         Pin.layoutDirection(.auto)
         
-        addSubview(container)
+        addSubview(contentView)
 
         logo.contentMode = .scaleAspectFit
-        container.addSubview(logo)
+        contentView.addSubview(logo)
         
         segmented.selectedSegmentIndex = 0
         segmented.tintColor = .pinLayoutColor
-        container.addSubview(segmented)
+        contentView.addSubview(segmented)
         
         textLabel.text = "Swift manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable.\n\nSwift manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable."
         textLabel.font = .systemFont(ofSize: 14)
         textLabel.numberOfLines = 0
         textLabel.lineBreakMode = .byWordWrapping
-        container.addSubview(textLabel)
+        contentView.addSubview(textLabel)
         
         separatorView.pin.height(1)
         separatorView.backgroundColor = .pinLayoutColor
-        container.addSubview(separatorView)
+        contentView.addSubview(separatorView)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -63,20 +63,13 @@ class IntroRTLView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        container.pin.top().bottom().start().end().margin(containerInsets())
+        // Layout the contentView using the view's safeArea with at least of 10 pixels all around.
+        let containerInsets = safeArea.minInsets(UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10))
+        contentView.pin.top().bottom().start().end().margin(containerInsets)
 
         logo.pin.top().start().size(100).aspectRatio().marginTop(10)
         segmented.pin.after(of: logo, aligned: .top).end().marginStart(10)
         textLabel.pin.below(of: segmented, aligned: .start).width(of: segmented).pinEdges().marginTop(10).fitSize()
         separatorView.pin.below(of: [logo, textLabel], aligned: .start).end(to: segmented.edge.end).marginTop(10)
-    }
-
-    fileprivate func containerInsets() -> UIEdgeInsets {
-        if #available(iOS 11.0, *) {
-            // The container margin must be at least of 10 pixels all around
-            return safeAreaInsets.minInsets(UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10))
-        } else {
-            return UIEdgeInsets(top: topLayoutGuide, left: 10, bottom: 0, right: 10)
-        }
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/IntroRTL/IntroRTLView.swift
+++ b/Example/PinLayoutSample/UI/Examples/IntroRTL/IntroRTLView.swift
@@ -36,22 +36,24 @@ class IntroRTLView: BaseView {
         // `UIApplication.shared.userInterfaceLayoutDirection` (< iOS 9)
         Pin.layoutDirection(.auto)
         
+        addSubview(container)
+
         logo.contentMode = .scaleAspectFit
-        addSubview(logo)
+        container.addSubview(logo)
         
         segmented.selectedSegmentIndex = 0
         segmented.tintColor = .pinLayoutColor
-        addSubview(segmented)
+        container.addSubview(segmented)
         
         textLabel.text = "Swift manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable.\n\nSwift manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable."
         textLabel.font = .systemFont(ofSize: 14)
         textLabel.numberOfLines = 0
         textLabel.lineBreakMode = .byWordWrapping
-        addSubview(textLabel)
+        container.addSubview(textLabel)
         
         separatorView.pin.height(1)
         separatorView.backgroundColor = .pinLayoutColor
-        addSubview(separatorView)
+        container.addSubview(separatorView)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -61,9 +63,20 @@ class IntroRTLView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        logo.pin.top().start().size(100).margin(topLayoutGuide + 10, 10, 10, 10)
-        segmented.pin.after(of: logo, aligned: .top).end().marginHorizontal(10)
+        container.pin.top().bottom().start().end().margin(containerInsets())
+
+        logo.pin.top().start().size(100).aspectRatio().marginTop(10)
+        segmented.pin.after(of: logo, aligned: .top).end().marginStart(10)
         textLabel.pin.below(of: segmented, aligned: .start).width(of: segmented).pinEdges().marginTop(10).fitSize()
         separatorView.pin.below(of: [logo, textLabel], aligned: .start).end(to: segmented.edge.end).marginTop(10)
+    }
+
+    fileprivate func containerInsets() -> UIEdgeInsets {
+        if #available(iOS 11.0, *) {
+            // The container margin must be at least of 10 pixels all around
+            return safeAreaInsets.minInsets(UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10))
+        } else {
+            return UIEdgeInsets(top: topLayoutGuide, left: 10, bottom: 0, right: 10)
+        }
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/MultiRelativeView/MultiRelativeView.swift
+++ b/Example/PinLayoutSample/UI/Examples/MultiRelativeView/MultiRelativeView.swift
@@ -21,6 +21,7 @@ import UIKit
 import PinLayout
 
 class MultiRelativeView: BaseView {
+    fileprivate let container = UIView()
     fileprivate let view1 = BasicView(text: "Relative view 1 (width: 20%, height: 50%)", color: .lightGray)
     fileprivate let view2 = BasicView(text: "Relative view 2 (width: 20%, height: 50%)", color: .lightGray)
     fileprivate let view = BasicView(text: "View layouted using two relative views: \n  - right(of: view1, aligned: .top)\n  - left(of: view2, aligned: .bottom)",
@@ -29,25 +30,33 @@ class MultiRelativeView: BaseView {
     override init() {
         super.init()
     
-        addSubview(view1)
-        addSubview(view2)
-        addSubview(view)
+        addSubview(container)
+
+        container.addSubview(view1)
+        container.addSubview(view2)
+        container.addSubview(view)
     }
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
     
-    func configure() {
-        
-    }
-
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        view1.pin.top(topLayoutGuide).left().width(20%).height(50%)
-        view2.pin.top(topLayoutGuide).right().width(20%).height(50%)
+        container.pin.top().bottom().left().right().margin(containerInsets())
+        
+        view1.pin.top().left().width(20%).height(50%)
+        view2.pin.top().right().width(20%).height(50%)
         
         view.pin.right(of: view1, aligned: .top).left(of: view2, aligned: .bottom).marginHorizontal(10)
+    }
+    
+    fileprivate func containerInsets() -> UIEdgeInsets {
+        if #available(iOS 11.0, *) {
+            return safeAreaInsets
+        } else {
+            return UIEdgeInsets(top: topLayoutGuide, left: 0, bottom: 0, right: 0)
+        }
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/MultiRelativeView/MultiRelativeView.swift
+++ b/Example/PinLayoutSample/UI/Examples/MultiRelativeView/MultiRelativeView.swift
@@ -21,7 +21,7 @@ import UIKit
 import PinLayout
 
 class MultiRelativeView: BaseView {
-    fileprivate let container = UIView()
+    fileprivate let contentView = UIView()
     fileprivate let view1 = BasicView(text: "Relative view 1 (width: 20%, height: 50%)", color: .lightGray)
     fileprivate let view2 = BasicView(text: "Relative view 2 (width: 20%, height: 50%)", color: .lightGray)
     fileprivate let view = BasicView(text: "View layouted using two relative views: \n  - right(of: view1, aligned: .top)\n  - left(of: view2, aligned: .bottom)",
@@ -30,11 +30,11 @@ class MultiRelativeView: BaseView {
     override init() {
         super.init()
     
-        addSubview(container)
+        addSubview(contentView)
 
-        container.addSubview(view1)
-        container.addSubview(view2)
-        container.addSubview(view)
+        contentView.addSubview(view1)
+        contentView.addSubview(view2)
+        contentView.addSubview(view)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -44,19 +44,12 @@ class MultiRelativeView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        container.pin.top().bottom().left().right().margin(containerInsets())
+        // Layout the contentView using the view's safeArea.
+        contentView.pin.top().bottom().left().right().margin(safeArea)
         
         view1.pin.top().left().width(20%).height(50%)
         view2.pin.top().right().width(20%).height(50%)
         
         view.pin.right(of: view1, aligned: .top).left(of: view2, aligned: .bottom).marginHorizontal(10)
-    }
-    
-    fileprivate func containerInsets() -> UIEdgeInsets {
-        if #available(iOS 11.0, *) {
-            return safeAreaInsets
-        } else {
-            return UIEdgeInsets(top: topLayoutGuide, left: 0, bottom: 0, right: 0)
-        }
     }
 }

--- a/Example/PinLayoutSample/UI/Examples/TableViewExample/Cells/MethodGroupHeader.swift
+++ b/Example/PinLayoutSample/UI/Examples/TableViewExample/Cells/MethodGroupHeader.swift
@@ -30,7 +30,7 @@ class MethodGroupHeader: UITableViewHeaderFooterView {
         
         titleLabel.font = UIFont.systemFont(ofSize: 20)
         titleLabel.sizeToFit()
-        addSubview(titleLabel)
+        contentView.addSubview(titleLabel)
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/Example/PinLayoutSample/UI/Examples/TableViewExample/TableViewExampleView.swift
+++ b/Example/PinLayoutSample/UI/Examples/TableViewExample/TableViewExampleView.swift
@@ -50,7 +50,7 @@ class TableViewExampleView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        tableView.pin.topLeft().bottomRight()
+        tableView.pin.top().bottom().left().right()
     }
 }
 

--- a/Example/PinLayoutSample/UI/Menu/MenuView.swift
+++ b/Example/PinLayoutSample/UI/Menu/MenuView.swift
@@ -18,6 +18,7 @@
 //  THE SOFTWARE.
 
 import UIKit
+import PinLayout
 
 protocol MenuViewDelegate: class {
     func didSelect(pageType: PageType)
@@ -48,7 +49,7 @@ class MenuView: BaseView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        tableView.pin.size(frame.size)
+        tableView.pin.top().left().size(100%)
     }
 }
 

--- a/PinLayout.xcodeproj/project.pbxproj
+++ b/PinLayout.xcodeproj/project.pbxproj
@@ -362,7 +362,6 @@
 					};
 					249EFE791E64FB4C00165E39 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = 4Q596JWQC5;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 					};
@@ -707,7 +706,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 4Q596JWQC5;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -728,7 +727,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 4Q596JWQC5;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This example layout an image, a UISegmentedControl, a label and a line separator
 override func layoutSubviews() {
    super.layoutSubviews() 
     
-   logo.pin.top().left().size(100).margin(10)
+   logo.pin.top().left().size(100).aspectRatio().margin(10)
    segmented.pin.right(of: logo, aligned: .top).right().marginHorizontal(10)
    textLabel.pin.below(of: segmented, aligned: .left).right().marginTop(10).marginRight(10).fitSize()
    separatorView.pin.below(of: [logo, textLabel], aligned: .left).right(to: segmented.edge.right).marginTop(10)
@@ -962,6 +962,8 @@ Set the top and bottom margins to the specified value.
 Apply the value to all margins (top, left, bottom, right)
 * **`margin(_ insets: UIEdgeInsets)`**  
 Set all margins using an UIEdgeInsets. This method is particularly useful to set all margins using iOS 11 `UIView.safeAreaInsets`.
+* **`margin(_ insets: NSDirectionalEdgeInsets) `**  
+Set all margins using an NSDirectionalEdgeInsets. This method is useful to set all margins using iOS 11 `UIView. directionalLayoutMargins` when layouting a view supporting RTL/LTR languages.
 * **`margin(_ vertical: CGFloat, _ horizontal: CGFloat)`**  
 Set the individually vertical margins (top, bottom) and horizontal margins (left, right, start, end)
 * **`margin(_ top: CGFloat, _ horizontal: CGFloat, _ bottom: CGFloat)`**  
@@ -1092,9 +1094,7 @@ NOTE: In that in that particular situation, the same results could have been ach
 	view.pin.left().right().marginHorizontal(20)
 ```
 
-
 <br>
-
 
 ## Warnings <a name="warnings"></a>
 ### PinLayout's warnings
@@ -1163,6 +1163,8 @@ Warnings can be disabled also in debug mode by setting the boolean Pin.logWarnin
 	   .right(of: statusIcon).left(of: accessoryView)
 	   .above(of: button).marginHorizontal(10)
 	```
+
+:pushpin: PinLayout's method call order is irrelevant, the layout result will always be the same. 
 
 <br/>
 
@@ -1292,6 +1294,9 @@ PinLayout also expose an Objective-C interface slightly different than the Swift
 
 *  **Q: When the device rotation change, the layout is not updated.**  
    **R:** PinLayout doesn't use auto layout constraints, it is a framework that manually layout views. For that reason you need to update the layout inside either `UIView.layoutSubviews()` or `UIViewController.viewDidLayoutSubviews()` to handle container size's changes, including device rotation. You'll also need to handle UITraitCollection changes for app's that support multitasking.
+   
+*  **Q: How to handle new iOS 11 `UIView.safeAreaInsets` and the iPhone X .**  
+   **R:** iOS 11 adds `UIView.safeAreaInsets` to particularly support the iPhone X landscape mode. In this mode `UIView.safeAreaInsets` has a left and right insets. The easiest way the handle this situation with PinLayout is to add a container view that will contains all your view's children, and simply adjust this container view to match the `safeAreaInsets`. All example in the [Examples App](#examples_app) handle correctly the `safeAreaInsets` and works on iPhone X in landscape mode.
    
 *  **Q: How can we adjust a UIView container to match all its children?**  
    **R:** The proposed solution is used by the **Form** example for its rounded corner background. Suppose you want to adjust a container height to match all its child (subviews). 

--- a/README.md
+++ b/README.md
@@ -1296,7 +1296,9 @@ PinLayout also expose an Objective-C interface slightly different than the Swift
    **R:** PinLayout doesn't use auto layout constraints, it is a framework that manually layout views. For that reason you need to update the layout inside either `UIView.layoutSubviews()` or `UIViewController.viewDidLayoutSubviews()` to handle container size's changes, including device rotation. You'll also need to handle UITraitCollection changes for app's that support multitasking.
    
 *  **Q: How to handle new iOS 11 `UIView.safeAreaInsets` and the iPhone X .**  
-   **R:** iOS 11 adds `UIView.safeAreaInsets` to particularly support the iPhone X landscape mode. In this mode `UIView.safeAreaInsets` has a left and right insets. The easiest way the handle this situation with PinLayout is to add a container view that will contains all your view's children, and simply adjust this container view to match the `safeAreaInsets`. All example in the [Examples App](#examples_app) handle correctly the `safeAreaInsets` and works on iPhone X in landscape mode.
+   **R:** iOS 11 has introduced `UIView.safeAreaInsets` to particularly support the iPhone X landscape mode. In this mode `UIView.safeAreaInsets` has a left and right insets. The easiest way the handle this situation with PinLayout is to add a contentView that will contains all your view's childs, and simply adjust this contentView view to match the `safeAreaInsets`. All example in the [Examples App](#examples_app) handle correctly the `safeAreaInsets` and works on iPhone X in landscape mode. 
+   
+   Note that **only the UIViewController's main view** must handle the `safeAreaInsets`, sub-views don't have to handle it.  
    
 *  **Q: How can we adjust a UIView container to match all its children?**  
    **R:** The proposed solution is used by the **Form** example for its rounded corner background. Suppose you want to adjust a container height to match all its child (subviews). 

--- a/Sources/PinLayout.swift
+++ b/Sources/PinLayout.swift
@@ -371,7 +371,7 @@ public protocol PinLayout {
      
      Available only on iOS 11 and higher.
      */
-    @available(iOS 11.0, *)
+    @available(tvOS 11.0, iOS 11.0, *)
     @discardableResult func margin(_ directionalInsets: NSDirectionalEdgeInsets) -> PinLayout
 
     /**

--- a/Sources/PinLayout.swift
+++ b/Sources/PinLayout.swift
@@ -371,8 +371,8 @@ public protocol PinLayout {
      
      Available only on iOS 11 and higher.
      */
-    //@available(iOS 11.0, *)
-    //@discardableResult func margin(_ directionalInsets: NSDirectionalEdgeInsets) -> PinLayout
+    @available(iOS 11.0, *)
+    @discardableResult func margin(_ directionalInsets: NSDirectionalEdgeInsets) -> PinLayout
 
     /**
      Set all margins to the specified value.

--- a/Sources/PinLayoutImpl+Coordinates.swift
+++ b/Sources/PinLayoutImpl+Coordinates.swift
@@ -300,7 +300,6 @@ extension PinLayoutImpl {
     
     internal func validateComputedWidth(_ width: CGFloat?) -> Bool {
         if let width = width, width < 0 {
-            warn("The computed width (\(width)) must be greater than or equal to zero. The view will keep its current width.")
             return false
         } else {
             return true
@@ -318,7 +317,6 @@ extension PinLayoutImpl {
     
     internal func validateComputedHeight(_ height: CGFloat?) -> Bool {
         if let height = height, height < 0 {
-            warn("The computed height (\(height)) must be greater than or equal to zero. The view will keep its current height.")
             return false
         } else {
             return true

--- a/Sources/PinLayoutImpl.swift
+++ b/Sources/PinLayoutImpl.swift
@@ -799,7 +799,7 @@ class PinLayoutImpl: PinLayout {
         return self
     }
     
-    /*@available(iOS 11.0, *)
+    @available(iOS 11.0, *)
     @discardableResult
     func margin(_ directionalInsets: NSDirectionalEdgeInsets) -> PinLayout {
         marginTop = directionalInsets.top
@@ -807,7 +807,7 @@ class PinLayoutImpl: PinLayout {
         marginStart(directionalInsets.leading)
         marginEnd(directionalInsets.trailing)
         return self
-    }*/
+    }
 
     @discardableResult
     func margin(_ value: CGFloat) -> PinLayout {

--- a/Sources/PinLayoutImpl.swift
+++ b/Sources/PinLayoutImpl.swift
@@ -799,7 +799,7 @@ class PinLayoutImpl: PinLayout {
         return self
     }
     
-    @available(iOS 11.0, *)
+    @available(tvOS 11.0, iOS 11.0, *)
     @discardableResult
     func margin(_ directionalInsets: NSDirectionalEdgeInsets) -> PinLayout {
         marginTop = directionalInsets.top

--- a/Tests/AdjustSizeSpec.swift
+++ b/Tests/AdjustSizeSpec.swift
@@ -111,13 +111,6 @@ class AdjustSizeSpec: QuickSpec {
                 aView.pin.width(of: aViewChild)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 50.0, height: 60.0)))
             }
-        
-            // Negative width
-            it("should adjust the left but warn that the width won't be applied due to a negative width") {
-                aView.pin.left(300).right(300)
-                expect(aView.frame).to(equal(CGRect(x: 300.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["computed width (-200.0)", "greater than or equal to zero", "view will keep its current width"]))
-            }
         }
         
         describe("the result of the height(...) methods") {
@@ -150,13 +143,6 @@ class AdjustSizeSpec: QuickSpec {
             it("should adjust the height of aView") {
                 aView.pin.height(of: aViewChild)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 100.0, height: 30.0)))
-            }
-            
-            // Negative height
-            it("should adjust the top but warn that the height won't be applied due to a negative height") {
-                aView.pin.top(300).bottom(300)
-                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 300.0, width: 100.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["computed height (-200.0)", "greater than or equal to zero", "view will keep its current height"]))
             }
         }
         

--- a/Tests/MarginsSpec.swift
+++ b/Tests/MarginsSpec.swift
@@ -564,7 +564,7 @@ class MarginsSpec: QuickSpec {
                 expect(aView.frame).to(equal(CGRect(x: 20.0, y: 10.0, width: 340.0, height: 360.0)))
             }
             
-            /*if #available(iOS 11.0, *) {
+            if #available(iOS 11.0, *) {
                 it("should adjust the aView") {
                     Pin.layoutDirection(.ltr)
                     aView.pin.top().bottom().start().end().margin(NSDirectionalEdgeInsets(top: 10, leading: 20, bottom: 30, trailing: 40))
@@ -582,7 +582,7 @@ class MarginsSpec: QuickSpec {
                     aView.pin.top().bottom().start().end().margin(NSDirectionalEdgeInsets(top: 10, leading: 20, bottom: 30, trailing: 40))
                     expect(aView.frame).to(equal(CGRect(x: 20.0, y: 10.0, width: 340.0, height: 360.0)))
                 }
-            }*/
+            }
         }
     }
 }


### PR DESCRIPTION
* Update all examples so they support iOS 11 and iPhoneX landscape mode. They use the new `UIView.safeAreaInsets` property.
* Add method `margin(_ directionalInsets: NSDirectionalEdgeInsets)`