### PR TITLE
Add an PinLayout objective-c interface

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,26 @@
+opt_in_rules: # some rules are only opt-in
+  - closure_end_indentation
+  - closure_spacing
+  - explicit_init
+  - nimble_operator
+  - number_separator
+  - operator_usage_whitespace
+  - overridden_super_call
+  - private_outlet
+  - prohibited_super_call
+  - redundant_nil_coalescing
+
+disabled_rules: # rule identifiers to exclude from running
+  - function_body_length
+  - trailing_whitespace
+  - force_cast
+  - type_name
+  - file_length
+  - type_body_length
+  - cyclomatic_complexity
+  - nimble_operator
+  - variable_name
+  - line_length
+
+excluded: # paths to ignore during linting. overridden by `included`.
+  - Pods

--- a/Example/PinLayoutSample.xcodeproj/project.pbxproj
+++ b/Example/PinLayoutSample.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		241637741F8E4BC200EE703A /* IntroObjectiveCViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 241637711F8E4BC200EE703A /* IntroObjectiveCViewController.m */; };
+		241637771F8E4F9100EE703A /* IntroObjectiveCView.m in Sources */ = {isa = PBXBuildFile; fileRef = 241637761F8E4F9100EE703A /* IntroObjectiveCView.m */; };
 		2439CC281E6658C3003326FB /* PinLayout.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2439CC241E665858003326FB /* PinLayout.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2439CC2B1E6658CC003326FB /* PinLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2439CC241E665858003326FB /* PinLayout.framework */; };
 		2439CC351E665BF6003326FB /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2439CC331E665BF6003326FB /* MenuView.swift */; };
@@ -109,6 +111,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		241637701F8E4BC200EE703A /* IntroObjectiveCViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntroObjectiveCViewController.h; sourceTree = "<group>"; };
+		241637711F8E4BC200EE703A /* IntroObjectiveCViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IntroObjectiveCViewController.m; sourceTree = "<group>"; };
+		241637751F8E4F9100EE703A /* IntroObjectiveCView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntroObjectiveCView.h; sourceTree = "<group>"; };
+		241637761F8E4F9100EE703A /* IntroObjectiveCView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IntroObjectiveCView.m; sourceTree = "<group>"; };
 		2439CC1E1E665858003326FB /* PinLayout.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PinLayout.xcodeproj; path = ../PinLayout.xcodeproj; sourceTree = "<group>"; };
 		2439CC331E665BF6003326FB /* MenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
 		2439CC341E665BF6003326FB /* MenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
@@ -141,6 +147,7 @@
 		24CB999A1F29059B004EA7FB /* AdjustToContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdjustToContainerView.swift; sourceTree = "<group>"; };
 		24CB999B1F29059B004EA7FB /* AdjustToContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdjustToContainerViewController.swift; sourceTree = "<group>"; };
 		24CB999F1F290664004EA7FB /* ChoiceSelectorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChoiceSelectorView.swift; sourceTree = "<group>"; };
+		24CD1E8D1F8E4B0A00C3A54D /* PinLayoutSample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PinLayoutSample-Bridging-Header.h"; sourceTree = "<group>"; };
 		24D18D1B1F3DED0D008129EF /* IntroRTLView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntroRTLView.swift; sourceTree = "<group>"; };
 		24D18D1C1F3DED0D008129EF /* IntroRTLViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntroRTLViewController.swift; sourceTree = "<group>"; };
 		24DA374A1EF7F90600D1AB2F /* BaseFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseFormView.swift; sourceTree = "<group>"; };
@@ -181,6 +188,17 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		2416376F1F8E4BC200EE703A /* IntroObjectiveC */ = {
+			isa = PBXGroup;
+			children = (
+				241637761F8E4F9100EE703A /* IntroObjectiveCView.m */,
+				241637751F8E4F9100EE703A /* IntroObjectiveCView.h */,
+				241637711F8E4BC200EE703A /* IntroObjectiveCViewController.m */,
+				241637701F8E4BC200EE703A /* IntroObjectiveCViewController.h */,
+			);
+			path = IntroObjectiveC;
+			sourceTree = "<group>";
+		};
 		2439CC1F1E665858003326FB /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -209,9 +227,11 @@
 				2497CFEA1EF40B8100DFD13B /* Form */,
 				24F75B581EE5642C008DB567 /* Intro */,
 				24D18D181F3DECD6008129EF /* IntroRTL */,
+				2416376F1F8E4BC200EE703A /* IntroObjectiveC */,
 				2439CC5F1E665F66003326FB /* MultiRelativeView */,
 				2439CC631E66606D003326FB /* RelativeView */,
 				24A9C1EF1EF0542500F2CF64 /* TableViewExample */,
+				24CD1E8D1F8E4B0A00C3A54D /* PinLayoutSample-Bridging-Header.h */,
 			);
 			path = Examples;
 			sourceTree = "<group>";
@@ -544,7 +564,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/../Pods/Target Support Files/Pods-PinLayoutSample/Pods-PinLayoutSample-frameworks.sh",
-				"${PODS_ROOT}/Reveal-SDK/RevealServer-11/iOS/RevealServer.framework",
+				"${PODS_ROOT}/Reveal-SDK/RevealServer-10/iOS/RevealServer.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -605,6 +625,7 @@
 			files = (
 				24DA374B1EF7F90600D1AB2F /* BaseFormView.swift in Sources */,
 				24F75B5C1EE5644E008DB567 /* IntroViewController.swift in Sources */,
+				241637741F8E4BC200EE703A /* IntroObjectiveCViewController.m in Sources */,
 				2439CC541E665C6B003326FB /* RelativeView.swift in Sources */,
 				2439CC551E665C6B003326FB /* RelativeViewController.swift in Sources */,
 				24D18D1E1F3DED0D008129EF /* IntroRTLViewController.swift in Sources */,
@@ -624,6 +645,7 @@
 				24CB99981F290540004EA7FB /* MethodGroupHeader.swift in Sources */,
 				2439CC361E665BF6003326FB /* MenuViewController.swift in Sources */,
 				2439CC531E665C6B003326FB /* MultiRelativeViewController.swift in Sources */,
+				241637771F8E4F9100EE703A /* IntroObjectiveCView.m in Sources */,
 				24CB99A01F290664004EA7FB /* ChoiceSelectorView.swift in Sources */,
 				249326891EEEEE3D00BCB814 /* Stylesheet.swift in Sources */,
 				2439CC521E665C6B003326FB /* MultiRelativeView.swift in Sources */,
@@ -828,6 +850,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mirego.PinLayoutSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "PinLayoutSample/UI/Examples/PinLayoutSample-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
@@ -844,6 +868,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mirego.PinLayoutSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "PinLayoutSample/UI/Examples/PinLayoutSample-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;

--- a/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCView.h
+++ b/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCView.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2017, Mirego
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// - Neither the name of the Mirego nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef IntroObjectiveCView_h
+#define IntroObjectiveCView_h
+
+@import UIKit;
+
+@interface IntroObjectiveCView: UIView {
+    
+}
+
+- (void) setLayoutGuidesTop:(CGFloat)top;
+
+@end
+
+#endif /* IntroObjectiveCView_h */

--- a/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCView.m
+++ b/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCView.m
@@ -1,0 +1,79 @@
+// Copyright (c) 2017, Mirego
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// - Neither the name of the Mirego nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+#import "IntroObjectiveCView.h"
+@import PinLayout;
+
+
+@implementation IntroObjectiveCView {
+    CGFloat topLayoutGuide;
+    UIImageView* logo;
+    UISegmentedControl* segmented;
+    UILabel* textLabel;
+    UIView* separatorView;
+}
+
+- (id)initWithFrame:(CGRect)frame {
+    if ((self = [super initWithFrame:frame])) {
+        topLayoutGuide = 0;
+        self.backgroundColor = UIColor.whiteColor;
+        
+        logo = [[UIImageView alloc] initWithImage: [UIImage imageNamed:@"PinLayout-logo" inBundle:nil compatibleWithTraitCollection:nil]];
+        [self addSubview:logo];
+        
+        segmented = [[UISegmentedControl alloc] initWithItems: @[@"Intro", @"1", @"2"]];
+        [self addSubview:segmented];
+        
+        textLabel = [[UILabel alloc] init];
+        textLabel.text = @"Swift manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable.\n\nSwift manual views layouting without auto layout, no magic, pure code, full control. Concise syntax, readable & chainable.";
+        textLabel.font = [UIFont systemFontOfSize:14];
+        textLabel.numberOfLines = 0;
+        textLabel.lineBreakMode = NSLineBreakByWordWrapping;
+        [self addSubview:textLabel];
+        
+        separatorView = [[UIView alloc] init];
+        separatorView.backgroundColor = UIColor.grayColor;
+        
+        [self addSubview:separatorView];
+    }
+    return self;
+}
+
+- (void) layoutSubviews {
+    [super layoutSubviews];
+    
+    [[[[[[logo.pinObjc top] left] width:100] aspectRatio] marginWithTop:topLayoutGuide + 10 horizontal:10 bottom:10] layout];
+    [[[[segmented.pinObjc rightOf:logo aligned:VerticalAlignTop] right] marginHorizontal:10] layout];
+    [[[[[[textLabel.pinObjc belowOf:segmented aligned:HorizontalAlignLeft] widthOf:segmented] pinEdges] marginTop:10] fitSize] layout];
+    [[[[[separatorView.pinObjc belowOfViews:@[logo, textLabel] aligned:HorizontalAlignLeft] rightTo:segmented.edge.right] height:1] marginTop:10] layout];
+}
+
+- (void) setLayoutGuidesTop:(CGFloat)top {
+    topLayoutGuide = top;
+}
+@end

--- a/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCViewController.h
+++ b/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCViewController.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2017, Mirego
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// - Neither the name of the Mirego nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef IntroObjectiveC_h
+#define IntroObjectiveC_h
+
+@import UIKit;
+
+@interface IntroObjectiveCViewController: UIViewController {
+}
+@end
+
+#endif /* IntroObjectiveC_h */

--- a/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCViewController.m
+++ b/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCViewController.m
@@ -1,0 +1,52 @@
+// Copyright (c) 2017, Mirego
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// - Neither the name of the Mirego nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+#import "IntroObjectiveCViewController.h"
+
+#import "IntroObjectiveCView.h"
+
+@implementation IntroObjectiveCViewController {
+}
+
+- (id) init {
+    if (self = [super init]){
+        
+    }
+    return self;
+}
+
+- (void)loadView {
+    self.view = [[IntroObjectiveCView alloc] initWithFrame: CGRectZero];
+}
+
+- (void)viewWillLayoutSubviews {
+    [super viewWillLayoutSubviews];    
+    [((IntroObjectiveCView*)self.view) setLayoutGuidesTop:self.topLayoutGuide.length];
+}
+
+@end

--- a/Example/PinLayoutSample/UI/Examples/New Group/ObjectiveC.m
+++ b/Example/PinLayoutSample/UI/Examples/New Group/ObjectiveC.m
@@ -1,0 +1,9 @@
+//
+//  ObjectiveC.m
+//  PinLayoutSample
+//
+//  Created by DION, Luc (MTL) on 2017-10-11.
+//  Copyright © 2017 Mirego. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>

--- a/Example/PinLayoutSample/UI/Examples/PinLayoutSample-Bridging-Header.h
+++ b/Example/PinLayoutSample/UI/Examples/PinLayoutSample-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "IntroObjectiveCViewController.h"

--- a/Example/PinLayoutSample/UI/Menu/MenuViewController.swift
+++ b/Example/PinLayoutSample/UI/Menu/MenuViewController.swift
@@ -36,6 +36,7 @@ enum PageType: Int {
     case multiRelativePositions
     case autoAdjustingSize
     case introRTL
+    case introObjC
     
     case count
     
@@ -49,6 +50,7 @@ enum PageType: Int {
         case .multiRelativePositions:     return "Multiple Relatives Positionning"
         case .autoAdjustingSize:          return "Auto adjusting size"
         case .introRTL:                   return "PinLayout's right-to-left language support"
+        case .introObjC:                  return "Objective-C PinLayout Example"
         case .count:                      return ""
         }
     }
@@ -63,6 +65,7 @@ enum PageType: Int {
         case .multiRelativePositions:     return MultiRelativeViewController(pageType: self)
         case .autoAdjustingSize:          return AutoAdjustingSizeViewController(pageType: self)
         case .introRTL:                   return IntroRTLViewController(pageType: self)
+        case .introObjC:                  return IntroObjectiveCViewController()
         case .count:                      return UIViewController()
         }
     }

--- a/PinLayout.podspec
+++ b/PinLayout.podspec
@@ -7,132 +7,21 @@
 #
 
 Pod::Spec.new do |s|
-
-  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  These will help people to find your library, and whilst it
-  #  can feel like a chore to fill in it's definitely to your advantage. The
-  #  summary should be tweet-length, and the description more in depth.
-  #
-
   s.name         = "PinLayout"
   s.version      = "1.3.3"
   s.summary      = "Fast Swift UIViews layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable."
-
-  # This description is used to generate tags and improve search results.
-  #   * Think: What does it do? Why did you write it? What is the focus?
-  #   * Try to keep it short, snappy and to the point.
-  #   * Write the description between the DESC delimiters below.
-  #   * Finally, don't worry about the indent, CocoaPods strips it!
-  s.description  = <<-DESC 
-  
-* Fast Swift UIViews layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable.
-* Support left to right (LTR) and right to left (RTL) languages.
-                   DESC
+  s.description  = "Fast Swift UIViews layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable."
 
   s.homepage     = "https://mirego.github.io/PinLayout/"
-  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
-
-
-  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Licensing your code is important. See http://choosealicense.com for more info.
-  #  CocoaPods will detect a license file if there is a named LICENSE*
-  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
-  #
-
   s.license      = "BSD 3-clause"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-
-
-  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Specify the authors of the library, with email addresses. Email addresses
-  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
-  #  accepts just a name if you'd rather not provide an email address.
-  #
-  #  Specify a social_media_url where others can refer to, for example a twitter
-  #  profile URL.
-  #
-
   s.author             = { 
     "Luc Dion" => "ldion@mirego.com",
     "Luc Dion" => "luc_dion@yahoo.com"
-# TODO Add more
      }
   
-  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  If this Pod runs only on iOS or OS X, then specify the platform and
-  #  the deployment target. You can optionally include the target after the platform.
-  #
-
-  # s.platform     = :ios
   s.platform     = :ios, "8.0"
   s.tvos.deployment_target = '9.0'
 
-  #  When using multiple platforms
-  # s.ios.deployment_target = "5.0"
-  # s.osx.deployment_target = "10.7"
-  # s.watchos.deployment_target = "2.0"
-  # s.tvos.deployment_target = "9.0"
-
-
-  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Specify the location from where the source should be retrieved.
-  #  Supports git, hg, bzr, svn and HTTP.
-  #
-
   s.source       = { :git => "https://github.com/mirego/PinLayout.git", :tag => "#{s.version}" }
-
-
-  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  CocoaPods is smart about how it includes source code. For source files
-  #  giving a folder will include any swift, h, m, mm, c & cpp files.
-  #  For header files it will include any header in the folder.
-  #  Not including the public_header_files will make all headers public.
-  #
-
   s.source_files  = "Sources/**/*.swift"
-
-
-  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  A list of resources included with the Pod. These are copied into the
-  #  target bundle with a build phase script. Anything else will be cleaned.
-  #  You can preserve files from being cleaned, please don't preserve
-  #  non-essential files like tests, examples and documentation.
-  #
-
-  # s.resource  = "icon.png"
-  # s.resources = "Resources/*.png"
-  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
-
-
-  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Link your library with frameworks, or libraries. Libraries do not include
-  #  the lib prefix of their name.
-  #
-
-  # s.framework  = "SomeFramework"
-  # s.frameworks = "SomeFramework", "AnotherFramework"
-
-  # s.library   = "iconv"
-  # s.libraries = "iconv", "xml2"
-
-
-  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  If your library depends on compiler flags you can set them in the xcconfig hash
-  #  where they will only apply to your library. If you depend on other Podspecs
-  #  you can include multiple dependencies to ensure it works.
-
-  # s.requires_arc = true
-
-  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
-  # s.dependency "JSONKit", "~> 1.4"
-
 end

--- a/PinLayout.xcodeproj/project.pbxproj
+++ b/PinLayout.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		240F88BE1F0C066800280FC8 /* JustifyAlignSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240F88BC1F0C042500280FC8 /* JustifyAlignSpec.swift */; };
 		240F88C11F0C1F5000280FC8 /* WarningSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240F88BF1F0C1ED900280FC8 /* WarningSpec.swift */; };
+		241A277D1F8E958F00B1AD39 /* PinLayoutObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241A277B1F8E958F00B1AD39 /* PinLayoutObjC.swift */; };
+		241A277E1F8E958F00B1AD39 /* PinLayoutObjCImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241A277C1F8E958F00B1AD39 /* PinLayoutObjCImpl.swift */; };
 		242723731F008BF7006A5C3A /* MinMaxWidthHeightSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 242723711F008B85006A5C3A /* MinMaxWidthHeightSpec.swift */; };
 		242E8DC31EED5AB2005935FB /* RelativePositionMultipleViewsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 242E8DC11EED5982005935FB /* RelativePositionMultipleViewsSpec.swift */; };
 		244C6E151E776A0C0074FC74 /* MarginsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244C6E141E776A0C0074FC74 /* MarginsSpec.swift */; };
@@ -81,6 +83,8 @@
 /* Begin PBXFileReference section */
 		240F88BC1F0C042500280FC8 /* JustifyAlignSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JustifyAlignSpec.swift; sourceTree = "<group>"; };
 		240F88BF1F0C1ED900280FC8 /* WarningSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WarningSpec.swift; sourceTree = "<group>"; };
+		241A277B1F8E958F00B1AD39 /* PinLayoutObjC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinLayoutObjC.swift; sourceTree = "<group>"; };
+		241A277C1F8E958F00B1AD39 /* PinLayoutObjCImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinLayoutObjCImpl.swift; sourceTree = "<group>"; };
 		242723711F008B85006A5C3A /* MinMaxWidthHeightSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MinMaxWidthHeightSpec.swift; sourceTree = "<group>"; };
 		242E8DC11EED5982005935FB /* RelativePositionMultipleViewsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelativePositionMultipleViewsSpec.swift; sourceTree = "<group>"; };
 		244C6E141E776A0C0074FC74 /* MarginsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarginsSpec.swift; sourceTree = "<group>"; };
@@ -156,6 +160,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		241A277A1F8E958F00B1AD39 /* ObjectiveC */ = {
+			isa = PBXGroup;
+			children = (
+				241A277B1F8E958F00B1AD39 /* PinLayoutObjC.swift */,
+				241A277C1F8E958F00B1AD39 /* PinLayoutObjCImpl.swift */,
+			);
+			path = ObjectiveC;
+			sourceTree = "<group>";
+		};
 		249EFE701E64FB4C00165E39 = {
 			isa = PBXGroup;
 			children = (
@@ -184,6 +197,7 @@
 				24949A2D1EF69474003643D3 /* PinLayout+Filters.swift */,
 				24D18D231F3E37DD008129EF /* PinLayoutGlobals.swift */,
 				DFA06B031E8B38B300B6D5E7 /* Impl */,
+				241A277A1F8E958F00B1AD39 /* ObjectiveC */,
 				DF11A3741E834181008B33E5 /* Supporting Files */,
 			);
 			path = Sources;
@@ -485,10 +499,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				24D18D241F3E37DD008129EF /* PinLayoutGlobals.swift in Sources */,
+				241A277E1F8E958F00B1AD39 /* PinLayoutObjCImpl.swift in Sources */,
 				24D18D121F350157008129EF /* UIView+LTR.swift in Sources */,
 				DF11A3711E833F03008B33E5 /* TypesImpl.swift in Sources */,
 				24949A2C1EF55216003643D3 /* PinLayoutImpl+Warning.swift in Sources */,
 				DFC97CA71E8A8F2C001545D5 /* PinLayout.swift in Sources */,
+				241A277D1F8E958F00B1AD39 /* PinLayoutObjC.swift in Sources */,
 				24949A2E1EF69474003643D3 /* PinLayout+Filters.swift in Sources */,
 				24BBE6351F50FA1D0091D5E9 /* UnitTests.swift in Sources */,
 				DFC97CA51E8A8EB3001545D5 /* PinLayoutImpl.swift in Sources */,

--- a/Podfile
+++ b/Podfile
@@ -15,6 +15,6 @@ target 'PinLayoutSample' do
   project 'Example/PinLayoutSample.xcodeproj'
 
   # Debug only
-  pod 'Reveal-SDK', :configurations => ['Debug']
+  pod 'Reveal-SDK', '~> 10', :configurations => ['Debug']
   pod 'SwiftLint'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - Nimble (7.0.1)
   - Quick (1.1.0)
-  - Reveal-SDK (11)
+  - Reveal-SDK (10)
   - SwiftLint (0.22.0)
 
 DEPENDENCIES:
   - Nimble
   - Quick
-  - Reveal-SDK
+  - Reveal-SDK (~> 10)
   - SwiftLint
 
 SPEC CHECKSUMS:
   Nimble: 657d000e11df8aebe27cdaf9d244de7f30ed87f7
   Quick: dafc587e21eed9f4cab3249b9f9015b0b7a7f71d
-  Reveal-SDK: 7fa13d04bb55db61ff2342a990cf731d5159361d
+  Reveal-SDK: 7869ddf1f902cabbb07a1f0dd06bd25861a126f7
   SwiftLint: 1134786caedd2caab0560d2f36b76414a5a56808
 
-PODFILE CHECKSUM: 3b67fc05230707b4ff0a4b82edf3192f17967214
+PODFILE CHECKSUM: 551f30133c18993f273ef8fc6b94eac44639e0ff
 
 COCOAPODS: 1.3.1

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Extremely Fast views layouting without auto layout. No magic, pure code, full co
 ### Requirements
 * iOS 8.0+ / tvOS 9.0+
 * Xcode 8.0+ / Xcode 9.0
-* Swift 3.0+ / Swift 4.0
+* Swift 3.0+ / Swift 4.0 / Objective-C
 
 ### Content
 
@@ -43,6 +43,7 @@ Extremely Fast views layouting without auto layout. No magic, pure code, full co
   * [Warnings](#warnings)
   * [More examples](#more_examples)
 * [Examples App](#examples_app)
+* [Using PinLayout with Objective-C](#objective_c_interface)
 * [Installation](#installation)
 * [FAQ](#faq)
 * [Comments, ideas, suggestions, issues, ....](#comments)
@@ -1261,6 +1262,7 @@ There is an Example app that expose some usage example on PinLayout, including:
 * An example of UITableView with variable height cells.
 * Example showing a form
 * Example showing relative positioning.
+* Example using objective-c
 * ...
 
 :pushpin: Tap on images to see the example's source code.
@@ -1276,6 +1278,13 @@ There is an Example app that expose some usage example on PinLayout, including:
 </p>
 
 This app is available in the `Example` folder. Note that you must do a `pod install` before running the example project.
+
+<br>
+
+## Using PinLayout with Objective-C <a name="objective_c_interface"></a>
+PinLayout also expose an Objective-C interface slightly different than the Swift interface. 
+
+[See here for more details](docs/objective_c.md).
 
 <br>
 
@@ -1304,7 +1313,7 @@ This app is available in the `Example` folder. Note that you must do a `pod inst
 <br>
 
 
-### Questions, comments, ideas, suggestions, issues, .... <a name="comments"></a>
+## Questions, comments, ideas, suggestions, issues, .... <a name="comments"></a>
 If you have questions, you can checks already [answered questions here.](https://github.com/mirego/PinLayout/issues?q=is%3Aissue+is%3Aclosed+label%3Aquestion)
 
 For any **comments**, **ideas**, **suggestions**, **issues**, simply open an [issue](https://github.com/mirego/PinLayout/issues).
@@ -1316,7 +1325,7 @@ If you'd like to contribute, you're welcome!
 <br>
 
 
-### Thanks
+## Thanks
 PinLayout was inspired by other great layout frameworks, including:
 
 * HTML's CSS: Management of margins in absolute positioning and bottom/right position coordinates.

--- a/Sources/ObjectiveC/PinLayoutObjC.swift
+++ b/Sources/ObjectiveC/PinLayoutObjC.swift
@@ -1,0 +1,334 @@
+// Copyright (c) 2017, Mirego
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// - Neither the name of the Mirego nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+
+#if os(iOS) || os(tvOS)
+import UIKit
+    
+// MARK: - PinLayout UIView's extension
+public extension UIView {
+    // Expose PinLayout's objective-c interface.
+    public var pinObjc: PinLayoutObjC {
+        return PinLayoutObjCImpl(view: self)
+    }
+}
+
+/**
+ We must have a different interface for objective-c. The PinLayout's Swift interface use some
+ feature not available to objective-c, including overloading.
+ */
+@objc public protocol PinLayoutObjC {
+    /**
+     With the Objective-C interface, you must call the \"layout\" method to ensure the view is layouted correctly.
+     Ex:
+         [[[textLabel.pin_objc top] left] layout];"
+         [[[textLabel.pin_objc top] left] layout];"
+     */
+    func layout()
+    
+    @discardableResult func top() -> PinLayoutObjC
+    @discardableResult func top(_ value: CGFloat) -> PinLayoutObjC
+    @discardableResult func top(percent: CGFloat) -> PinLayoutObjC
+    
+    @discardableResult func left() -> PinLayoutObjC
+    @discardableResult func left(_ value: CGFloat) -> PinLayoutObjC
+    @discardableResult func left(percent: CGFloat) -> PinLayoutObjC
+    
+    @discardableResult func bottom() -> PinLayoutObjC
+    @discardableResult func bottom(_ value: CGFloat) -> PinLayoutObjC
+    @discardableResult func bottom(percent: CGFloat) -> PinLayoutObjC
+    
+    @discardableResult func right() -> PinLayoutObjC
+    @discardableResult func right(_ value: CGFloat) -> PinLayoutObjC
+    @discardableResult func right(percent: CGFloat) -> PinLayoutObjC
+    
+    @discardableResult func hCenter() -> PinLayoutObjC
+    @discardableResult func hCenter(_ value: CGFloat) -> PinLayoutObjC
+    @discardableResult func hCenter(percent: CGFloat) -> PinLayoutObjC
+    
+    @discardableResult func vCenter() -> PinLayoutObjC
+    @discardableResult func vCenter(_ value: CGFloat) -> PinLayoutObjC
+    @discardableResult func vCenter(percent: CGFloat) -> PinLayoutObjC
+    
+    // RTL support
+    @discardableResult func start() -> PinLayoutObjC
+    @discardableResult func start(_ value: CGFloat) -> PinLayoutObjC
+    @discardableResult func start(percent: CGFloat) -> PinLayoutObjC
+    @discardableResult func end() -> PinLayoutObjC
+    @discardableResult func end(_ value: CGFloat) -> PinLayoutObjC
+    @discardableResult func end(percent: CGFloat) -> PinLayoutObjC
+    
+    //
+    // MARK: Layout using edges
+    //
+    @discardableResult func top(to edge: VerticalEdge) -> PinLayoutObjC
+    @discardableResult func vCenter(to edge: VerticalEdge) -> PinLayoutObjC
+    @discardableResult func bottom(to edge: VerticalEdge) -> PinLayoutObjC
+    @discardableResult func left(to edge: HorizontalEdge) -> PinLayoutObjC
+    @discardableResult func hCenter(to edge: HorizontalEdge) -> PinLayoutObjC
+    @discardableResult func right(to edge: HorizontalEdge) -> PinLayoutObjC
+    // RTL support
+    @discardableResult func start(to edge: HorizontalEdge) -> PinLayoutObjC
+    @discardableResult func end(to edge: HorizontalEdge) -> PinLayoutObjC
+    
+    //
+    // MARK: Layout using anchors
+    //
+    @discardableResult func topLeft(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func topLeft() -> PinLayoutObjC
+    @discardableResult func topStart(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func topStart() -> PinLayoutObjC
+    
+    @discardableResult func topCenter(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func topCenter() -> PinLayoutObjC
+    
+    @discardableResult func topRight(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func topRight() -> PinLayoutObjC
+    @discardableResult func topEnd(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func topEnd() -> PinLayoutObjC
+    
+    @discardableResult func centerLeft(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func centerLeft() -> PinLayoutObjC
+    @discardableResult func centerStart(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func centerStart() -> PinLayoutObjC
+    
+    @discardableResult func center(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func center() -> PinLayoutObjC
+    
+    @discardableResult func centerRight(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func centerRight() -> PinLayoutObjC
+    @discardableResult func centerEnd(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func centerEnd() -> PinLayoutObjC
+    
+    @discardableResult func bottomLeft(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func bottomLeft() -> PinLayoutObjC
+    @discardableResult func bottomStart(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func bottomStart() -> PinLayoutObjC
+    
+    @discardableResult func bottomCenter(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func bottomCenter() -> PinLayoutObjC
+    
+    @discardableResult func bottomRight(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func bottomRight() -> PinLayoutObjC
+    @discardableResult func bottomEnd(to anchor: Anchor) -> PinLayoutObjC
+    @discardableResult func bottomEnd() -> PinLayoutObjC
+    
+    //
+    // MARK: Layout using relative positioning
+    //
+    @discardableResult func above(of: UIView) -> PinLayoutObjC
+    @discardableResult func above(ofViews: [UIView]) -> PinLayoutObjC
+    @discardableResult func above(of: UIView, aligned: HorizontalAlign) -> PinLayoutObjC
+    @discardableResult func above(ofViews: [UIView], aligned: HorizontalAlign) -> PinLayoutObjC
+
+    @discardableResult func below(of: UIView) -> PinLayoutObjC
+    @discardableResult func below(ofViews: [UIView]) -> PinLayoutObjC
+    @discardableResult func below(of: UIView, aligned: HorizontalAlign) -> PinLayoutObjC
+    @discardableResult func below(ofViews: [UIView], aligned: HorizontalAlign) -> PinLayoutObjC
+
+    @discardableResult func left(of: UIView) -> PinLayoutObjC
+    @discardableResult func left(ofViews: [UIView]) -> PinLayoutObjC
+    @discardableResult func left(of: UIView, aligned: VerticalAlign) -> PinLayoutObjC
+    @discardableResult func left(ofViews: [UIView], aligned: VerticalAlign) -> PinLayoutObjC
+
+    @discardableResult func right(of: UIView) -> PinLayoutObjC
+    @discardableResult func right(ofViews: [UIView]) -> PinLayoutObjC
+    @discardableResult func right(of: UIView, aligned: VerticalAlign) -> PinLayoutObjC
+    @discardableResult func right(ofViews: [UIView], aligned: VerticalAlign) -> PinLayoutObjC
+
+    // RTL support
+    @discardableResult func before(of: UIView) -> PinLayoutObjC
+    @discardableResult func before(ofViews: [UIView]) -> PinLayoutObjC
+    @discardableResult func before(of: UIView, aligned: VerticalAlign) -> PinLayoutObjC
+    @discardableResult func before(ofViews: [UIView], aligned: VerticalAlign) -> PinLayoutObjC
+    @discardableResult func after(of: UIView) -> PinLayoutObjC
+    @discardableResult func after(ofViews: [UIView]) -> PinLayoutObjC
+    @discardableResult func after(of: UIView, aligned: VerticalAlign) -> PinLayoutObjC
+    @discardableResult func after(ofViews: [UIView], aligned: VerticalAlign) -> PinLayoutObjC
+
+    //
+    // MARK: justify / align
+    //
+    @discardableResult func justify(_: HorizontalAlign) -> PinLayoutObjC
+    @discardableResult func align(_: VerticalAlign) -> PinLayoutObjC
+
+    //
+    // MARK: Width, height and size
+    //
+    @discardableResult func width(_ width: CGFloat) -> PinLayoutObjC
+    @discardableResult func width(percent: CGFloat) -> PinLayoutObjC
+    @discardableResult func width(of view: UIView) -> PinLayoutObjC
+    @discardableResult func minWidth(_ width: CGFloat) -> PinLayoutObjC
+    @discardableResult func minWidth(percent: CGFloat) -> PinLayoutObjC
+    @discardableResult func maxWidth(_ width: CGFloat) -> PinLayoutObjC
+    @discardableResult func maxWidth(percent: CGFloat) -> PinLayoutObjC
+
+    @discardableResult func height(_ height: CGFloat) -> PinLayoutObjC
+    @discardableResult func height(percent: CGFloat) -> PinLayoutObjC
+    @discardableResult func height(of view: UIView) -> PinLayoutObjC
+    @discardableResult func minHeight(_ height: CGFloat) -> PinLayoutObjC
+    @discardableResult func minHeight(percent: CGFloat) -> PinLayoutObjC
+    @discardableResult func maxHeight(_ height: CGFloat) -> PinLayoutObjC
+    @discardableResult func maxHeight(percent: CGFloat) -> PinLayoutObjC
+
+    @discardableResult func size(_ size: CGSize) -> PinLayoutObjC
+    @discardableResult func size(length: CGFloat) -> PinLayoutObjC
+    @discardableResult func size(percent: CGFloat) -> PinLayoutObjC
+    @discardableResult func size(of view: UIView) -> PinLayoutObjC
+
+    /**
+     Set the view aspect ratio.
+
+     AspectRatio is applied only if a single dimension (either width or height) can be determined,
+     in that case the aspect ratio will be used to compute the other dimension.
+
+     * AspectRatio is defined as the ratio between the width and the height (width / height).
+     * An aspect ratio of 2 means the width is twice the size of the height.
+     * AspectRatio respects the min (minWidth/minHeight) and the max (maxWidth/maxHeight)
+     dimensions of an item.
+     */
+    @discardableResult func aspectRatio(_ ratio: CGFloat) -> PinLayoutObjC
+    /**
+     Set the view aspect ratio using another UIView's aspect ratio.
+
+     AspectRatio is applied only if a single dimension (either width or height) can be determined,
+     in that case the aspect ratio will be used to compute the other dimension.
+
+     * AspectRatio is defined as the ratio between the width and the height (width / height).
+     * AspectRatio respects the min (minWidth/minHeight) and the max (maxWidth/maxHeight)
+     dimensions of an item.
+     */
+    @discardableResult func aspectRatio(of view: UIView) -> PinLayoutObjC
+    /**
+     If the layouted view is an UIImageView, this method will set the aspectRatio using
+     the UIImageView's image dimension.
+
+     For other types of views, this method as no impact.
+     */
+    @discardableResult func aspectRatio() -> PinLayoutObjC
+
+    @discardableResult func fitSize() -> PinLayoutObjC
+
+    //
+    // MARK: Margins
+    //
+
+    /**
+     Set the top margin.
+     */
+    @discardableResult func marginTop(_ value: CGFloat) -> PinLayoutObjC
+
+    /**
+     Set the left margin.
+     */
+    @discardableResult func marginLeft(_ value: CGFloat) -> PinLayoutObjC
+
+    /**
+     Set the bottom margin.
+     */
+    @discardableResult func marginBottom(_ value: CGFloat) -> PinLayoutObjC
+
+    /**
+     Set the right margin.
+     */
+    @discardableResult func marginRight(_ value: CGFloat) -> PinLayoutObjC
+
+    // RTL support
+    /**
+     Set the start margin.
+
+     Depends on the value of `Pin.layoutDirection(...)`:
+     * In LTR direction, start margin specify the **left** margin.
+     * In RTL direction, start margin specify the **right** margin.
+     */
+    @discardableResult func marginStart(_ value: CGFloat) -> PinLayoutObjC
+
+    /**
+     Set the end margin.
+
+     Depends on the value of `Pin.layoutDirection(...)`:
+     * In LTR direction, end margin specify the **right** margin.
+     * In RTL direction, end margin specify the **left** margin.
+     */
+    @discardableResult func marginEnd(_ value: CGFloat) -> PinLayoutObjC
+
+    /**
+     Set the left, right, start and end margins to the specified value.
+     */
+    @discardableResult func marginHorizontal(_ value: CGFloat) -> PinLayoutObjC
+
+    /**
+     Set the top and bottom margins to the specified value.
+     */
+    @discardableResult func marginVertical(_ value: CGFloat) -> PinLayoutObjC
+
+    /**
+     Set all margins using UIEdgeInsets.
+     This method is particularly useful to set all margins using iOS 11 `UIView.safeAreaInsets`.
+     */
+    @discardableResult func margin(insets: UIEdgeInsets) -> PinLayoutObjC
+
+    /**
+     Set margins using NSDirectionalEdgeInsets.
+     This method is particularly to set all margins using iOS 11 `UIView.directionalLayoutMargins`.
+
+     Available only on iOS 11 and higher.
+     */
+    //@available(iOS 11.0, *)
+    //@discardableResult func margin(_ directionalInsets: NSDirectionalEdgeInsets) -> PinLayoutObjC
+
+    /**
+     Set all margins to the specified value.
+     */
+    @discardableResult func margin(_ value: CGFloat) -> PinLayoutObjC
+
+    /**
+     Set individually vertical margins (top, bottom) and horizontal margins (left, right, start, end).
+     */
+    @discardableResult func margin(vertical: CGFloat, horizontal: CGFloat) -> PinLayoutObjC
+
+    /**
+     Set individually top, horizontal margins and bottom margin.
+     */
+    @discardableResult func margin(top: CGFloat, horizontal: CGFloat, bottom: CGFloat) -> PinLayoutObjC
+
+    /**
+     Set individually top, left, bottom and right margins.
+     */
+    @discardableResult func margin(top: CGFloat, left: CGFloat, bottom: CGFloat, right: CGFloat) -> PinLayoutObjC
+
+    /// Normally if only either left or right has been specified, PinLayout will MOVE the view to apply left or right margins.
+    /// This is also true even if the width has been set.
+    /// Calling pinEdges() will force PinLayout to pin the four edges and then apply left and/or right margins, and this without
+    /// moving the view.
+    ///
+    /// - Returns: PinLayout
+    @discardableResult func pinEdges() -> PinLayoutObjC
+}
+
+#endif

--- a/Sources/ObjectiveC/PinLayoutObjCImpl.swift
+++ b/Sources/ObjectiveC/PinLayoutObjCImpl.swift
@@ -1,0 +1,671 @@
+// Copyright (c) 2017, Mirego
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// - Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// - Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// - Neither the name of the Mirego nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#if os(iOS) || os(tvOS)
+import UIKit
+
+@objc public class PinLayoutObjCImpl: NSObject, PinLayoutObjC {
+    fileprivate var impl: PinLayoutImpl?
+    
+    init(view: UIView) {
+        impl = PinLayoutImpl(view: view)
+    }
+    
+    deinit {
+        if impl != nil {
+            impl?.warn("With the Objective-C interface, you must call the \"layout\" method to ensure the view is layouted correctly (ex: [[[textLabel.pin_objc top] left] layout];")
+        }
+    }
+    
+    public func layout() {
+        // With objective-c PinLayoutObjCImpl instance are sometimes deallocated only after the context has been quit. For this reason
+        // developpers must call the layout: method implicetely.
+        impl = nil
+    }
+    
+    public func top() -> PinLayoutObjC {
+        impl?.top()
+        return self
+    }
+    
+    public func top(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.top(value)
+        return self
+    }
+    
+    public func top(percent: CGFloat) -> PinLayoutObjC {
+        impl?.top(percent%)
+        return self
+    }
+    
+    public func left() -> PinLayoutObjC {
+        impl?.left()
+        return self
+    }
+    
+    public func left(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.left(value)
+        return self
+    }
+    
+    public func left(percent: CGFloat) -> PinLayoutObjC {
+        impl?.left(percent%)
+        return self
+    }
+    
+    public func bottom() -> PinLayoutObjC {
+        impl?.bottom()
+        return self
+    }
+    
+    public func bottom(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.bottom(value)
+        return self
+    }
+    
+    public func bottom(percent: CGFloat) -> PinLayoutObjC {
+        impl?.bottom(percent%)
+        return self
+    }
+    
+    public func right() -> PinLayoutObjC {
+        impl?.right()
+        return self
+    }
+    
+    public func right(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.right(value)
+        return self
+    }
+    
+    public func right(percent: CGFloat) -> PinLayoutObjC {
+        impl?.right(percent%)
+        return self
+    }
+    
+    public func hCenter() -> PinLayoutObjC {
+        impl?.hCenter()
+        return self
+    }
+    
+    public func hCenter(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.hCenter(value)
+        return self
+    }
+    
+    public func hCenter(percent: CGFloat) -> PinLayoutObjC {
+        impl?.hCenter(percent%)
+        return self
+    }
+    
+    public func vCenter() -> PinLayoutObjC {
+        impl?.vCenter()
+        return self
+    }
+    
+    public func vCenter(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.vCenter(value)
+        return self
+    }
+    
+    public func vCenter(percent: CGFloat) -> PinLayoutObjC {
+        impl?.vCenter(percent%)
+        return self
+    }
+    
+    public func start() -> PinLayoutObjC {
+        impl?.start()
+        return self
+    }
+    
+    public func start(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.start(value)
+        return self
+    }
+    
+    public func start(percent: CGFloat) -> PinLayoutObjC {
+        impl?.start(percent%)
+        return self
+    }
+    
+    public func end() -> PinLayoutObjC {
+        impl?.end()
+        return self
+    }
+    
+    public func end(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.end(value)
+        return self
+    }
+    
+    public func end(percent: CGFloat) -> PinLayoutObjC {
+        impl?.end(percent%)
+        return self
+    }
+    
+    public func top(to edge: VerticalEdge) -> PinLayoutObjC {
+        impl?.top(to: edge)
+        return self
+    }
+    
+    public func vCenter(to edge: VerticalEdge) -> PinLayoutObjC {
+        impl?.vCenter(to: edge)
+        return self
+    }
+    
+    public func bottom(to edge: VerticalEdge) -> PinLayoutObjC {
+        impl?.bottom(to: edge)
+        return self
+    }
+    
+    public func left(to edge: HorizontalEdge) -> PinLayoutObjC {
+        impl?.left(to: edge)
+        return self
+    }
+    
+    public func hCenter(to edge: HorizontalEdge) -> PinLayoutObjC {
+        impl?.hCenter(to: edge)
+        return self
+    }
+    
+    public func right(to edge: HorizontalEdge) -> PinLayoutObjC {
+        impl?.right(to: edge)
+        return self
+    }
+    
+    public func start(to edge: HorizontalEdge) -> PinLayoutObjC {
+        impl?.start(to: edge)
+        return self
+    }
+    
+    public func end(to edge: HorizontalEdge) -> PinLayoutObjC {
+        impl?.end(to: edge)
+        return self
+    }
+    
+    public func topLeft(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.topLeft(to: anchor)
+        return self
+    }
+    
+    public func topLeft() -> PinLayoutObjC {
+        impl?.topLeft()
+        return self
+    }
+    
+    public func topStart(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.topStart(to: anchor)
+        return self
+    }
+    
+    public func topStart() -> PinLayoutObjC {
+        impl?.topStart()
+        return self
+    }
+    
+    public func topCenter(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.topCenter(to: anchor)
+        return self
+    }
+    
+    public func topCenter() -> PinLayoutObjC {
+        impl?.topCenter()
+        return self
+    }
+    
+    public func topRight(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.topRight(to: anchor)
+        return self
+    }
+    
+    public func topRight() -> PinLayoutObjC {
+        impl?.topRight()
+        return self
+    }
+    
+    public func topEnd(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.topEnd(to: anchor)
+        return self
+    }
+    
+    public func topEnd() -> PinLayoutObjC {
+        impl?.topEnd()
+        return self
+    }
+    
+    public func centerLeft(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.centerLeft(to: anchor)
+        return self
+    }
+    
+    public func centerLeft() -> PinLayoutObjC {
+        impl?.centerLeft()
+        return self
+    }
+    
+    public func centerStart(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.centerStart(to: anchor)
+        return self
+    }
+    
+    public func centerStart() -> PinLayoutObjC {
+        impl?.centerStart()
+        return self
+    }
+    
+    public func center(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.center(to: anchor)
+        return self
+    }
+    
+    public func center() -> PinLayoutObjC {
+        impl?.center()
+        return self
+    }
+    
+    public func centerRight(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.centerRight(to: anchor)
+        return self
+    }
+    
+    public func centerRight() -> PinLayoutObjC {
+        impl?.centerRight()
+        return self
+    }
+    
+    public func centerEnd(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.centerEnd(to: anchor)
+        return self
+    }
+    
+    public func centerEnd() -> PinLayoutObjC {
+        impl?.centerEnd()
+        return self
+    }
+    
+    public func bottomLeft(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.bottomLeft(to: anchor)
+        return self
+    }
+    
+    public func bottomLeft() -> PinLayoutObjC {
+        impl?.bottomLeft()
+        return self
+    }
+    
+    public func bottomStart(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.bottomStart(to: anchor)
+        return self
+    }
+    
+    public func bottomStart() -> PinLayoutObjC {
+        impl?.bottomStart()
+        return self
+    }
+    
+    public func bottomCenter(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.bottomCenter(to: anchor)
+        return self
+    }
+    
+    public func bottomCenter() -> PinLayoutObjC {
+        impl?.bottomCenter()
+        return self
+    }
+    
+    public func bottomRight(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.bottomRight(to: anchor)
+        return self
+    }
+    
+    public func bottomRight() -> PinLayoutObjC {
+        impl?.bottomRight()
+        return self
+    }
+    
+    public func bottomEnd(to anchor: Anchor) -> PinLayoutObjC {
+        impl?.bottomEnd(to: anchor)
+        return self
+    }
+    
+    public func bottomEnd() -> PinLayoutObjC {
+        impl?.bottomEnd()
+        return self
+    }
+    
+    public func above(of view: UIView) -> PinLayoutObjC {
+        impl?.above(of: view)
+        return self
+    }
+    
+    public func above(ofViews views: [UIView]) -> PinLayoutObjC {
+        impl?.above(of: views)
+        return self
+    }
+    
+    public func above(of view: UIView, aligned: HorizontalAlign) -> PinLayoutObjC {
+        impl?.above(of: view, aligned: aligned)
+        return self
+    }
+    
+    public func above(ofViews views: [UIView], aligned: HorizontalAlign) -> PinLayoutObjC {
+        impl?.above(of: views, aligned: aligned)
+        return self
+    }
+    
+    public func below(of view: UIView) -> PinLayoutObjC {
+        impl?.below(of: view)
+        return self
+    }
+    
+    public func below(ofViews views: [UIView]) -> PinLayoutObjC {
+        impl?.below(of: views)
+        return self
+    }
+    
+    public func below(of view: UIView, aligned: HorizontalAlign) -> PinLayoutObjC {
+        impl?.below(of: view, aligned: aligned)
+        return self
+    }
+    
+    public func below(ofViews views: [UIView], aligned: HorizontalAlign) -> PinLayoutObjC {
+        impl?.below(of: views, aligned: aligned)
+        return self
+    }
+    
+    public func left(of view: UIView) -> PinLayoutObjC {
+        impl?.left(of: view)
+        return self
+    }
+    
+    public func left(ofViews views: [UIView]) -> PinLayoutObjC {
+        impl?.left(of: views)
+        return self
+    }
+    
+    public func left(of view: UIView, aligned: VerticalAlign) -> PinLayoutObjC {
+        impl?.left(of: view, aligned: aligned)
+        return self
+    }
+    
+    public func left(ofViews views: [UIView], aligned: VerticalAlign) -> PinLayoutObjC {
+        impl?.left(of: views, aligned: aligned)
+        return self
+    }
+    
+    public func right(of view: UIView) -> PinLayoutObjC {
+        impl?.right(of: view)
+        return self
+    }
+    
+    public func right(ofViews views: [UIView]) -> PinLayoutObjC {
+        impl?.right(of: views)
+        return self
+    }
+    
+    public func right(of view: UIView, aligned: VerticalAlign) -> PinLayoutObjC {
+        impl?.right(of: view, aligned: aligned)
+        return self
+    }
+    
+    public func right(ofViews views: [UIView], aligned: VerticalAlign) -> PinLayoutObjC {
+        impl?.right(of: views, aligned: aligned)
+        return self
+    }
+    
+    public func before(of view: UIView) -> PinLayoutObjC {
+        impl?.before(of: view)
+        return self
+    }
+    
+    public func before(ofViews views: [UIView]) -> PinLayoutObjC {
+        impl?.before(of: views)
+        return self
+    }
+    
+    public func before(of view: UIView, aligned: VerticalAlign) -> PinLayoutObjC {
+        impl?.before(of: view, aligned: aligned)
+        return self
+    }
+    
+    public func before(ofViews views: [UIView], aligned: VerticalAlign) -> PinLayoutObjC {
+        impl?.before(of: views, aligned: aligned)
+        return self
+    }
+    
+    public func after(of view: UIView) -> PinLayoutObjC {
+        impl?.after(of: view)
+        return self
+    }
+    
+    public func after(ofViews views: [UIView]) -> PinLayoutObjC {
+        impl?.after(of: views)
+        return self
+    }
+    
+    public func after(of view: UIView, aligned: VerticalAlign) -> PinLayoutObjC {
+        impl?.after(of: view, aligned: aligned)
+        return self
+    }
+    
+    public func after(ofViews views: [UIView], aligned: VerticalAlign) -> PinLayoutObjC {
+        impl?.after(of: views, aligned: aligned)
+        return self
+    }
+    
+    public func justify(_ align: HorizontalAlign) -> PinLayoutObjC {
+        impl?.justify(align)
+        return self
+    }
+    
+    public func align(_ align: VerticalAlign) -> PinLayoutObjC {
+        impl?.align(align)
+        return self
+    }
+    
+    public func width(_ width: CGFloat) -> PinLayoutObjC {
+        impl?.width(width)
+        return self
+    }
+    
+    public func width(percent: CGFloat) -> PinLayoutObjC {
+        impl?.width(percent%)
+        return self
+    }
+    
+    public func width(of view: UIView) -> PinLayoutObjC {
+        impl?.width(of: view)
+        return self
+    }
+    
+    public func minWidth(_ width: CGFloat) -> PinLayoutObjC {
+        impl?.minWidth(width)
+        return self
+    }
+    
+    public func minWidth(percent: CGFloat) -> PinLayoutObjC {
+        impl?.minWidth(percent%)
+        return self
+    }
+    
+    public func maxWidth(_ width: CGFloat) -> PinLayoutObjC {
+        impl?.maxWidth(width)
+        return self
+    }
+    
+    public func maxWidth(percent: CGFloat) -> PinLayoutObjC {
+        impl?.maxWidth(percent%)
+        return self
+    }
+    
+    public func height(_ height: CGFloat) -> PinLayoutObjC {
+        impl?.height(height)
+        return self
+    }
+    
+    public func height(percent: CGFloat) -> PinLayoutObjC {
+        impl?.height(percent%)
+        return self
+    }
+    
+    public func height(of view: UIView) -> PinLayoutObjC {
+        impl?.height(of: view)
+        return self
+    }
+    
+    public func minHeight(_ height: CGFloat) -> PinLayoutObjC {
+        impl?.minHeight(height)
+        return self
+    }
+    
+    public func minHeight(percent: CGFloat) -> PinLayoutObjC {
+        impl?.minHeight(percent%)
+        return self
+    }
+    
+    public func maxHeight(_ height: CGFloat) -> PinLayoutObjC {
+        impl?.maxHeight(height)
+        return self
+    }
+    
+    public func maxHeight(percent: CGFloat) -> PinLayoutObjC {
+        impl?.maxHeight(percent%)
+        return self
+    }
+    
+    public func size(_ size: CGSize) -> PinLayoutObjC {
+        impl?.size(size)
+        return self
+    }
+    
+    public func size(length: CGFloat) -> PinLayoutObjC {
+        impl?.size(length)
+        return self
+    }
+    
+    public func size(percent: CGFloat) -> PinLayoutObjC {
+        impl?.size(percent%)
+        return self
+    }
+    
+    public func size(of view: UIView) -> PinLayoutObjC {
+        impl?.size(of: view)
+        return self
+    }
+    
+    public func aspectRatio(_ ratio: CGFloat) -> PinLayoutObjC {
+        impl?.aspectRatio(ratio)
+        return self
+    }
+    
+    public func aspectRatio(of view: UIView) -> PinLayoutObjC {
+        impl?.aspectRatio(of: view)
+        return self
+    }
+    
+    public func aspectRatio() -> PinLayoutObjC {
+        impl?.aspectRatio()
+        return self
+    }
+    
+    public func fitSize() -> PinLayoutObjC {
+        impl?.fitSize()
+        return self
+    }
+    
+    public func marginTop(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.marginTop(value)
+        return self
+    }
+    
+    public func marginLeft(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.marginLeft(value)
+        return self
+    }
+    
+    public func marginBottom(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.marginBottom(value)
+        return self
+    }
+    
+    public func marginRight(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.marginRight(value)
+        return self
+    }
+    
+    public func marginStart(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.marginStart(value)
+        return self
+    }
+    
+    public func marginEnd(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.marginEnd(value)
+        return self
+    }
+    
+    public func marginHorizontal(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.marginHorizontal(value)
+        return self
+    }
+    
+    public func marginVertical(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.marginVertical(value)
+        return self
+    }
+    
+    public func margin(insets: UIEdgeInsets) -> PinLayoutObjC {
+        impl?.margin(insets)
+        return self
+    }
+    
+    public func margin(_ value: CGFloat) -> PinLayoutObjC {
+        impl?.margin(value)
+        return self
+    }
+    
+    public func margin(vertical: CGFloat, horizontal: CGFloat) -> PinLayoutObjC {
+        impl?.margin(vertical, horizontal)
+        return self
+    }
+    
+    public func margin(top: CGFloat, horizontal: CGFloat, bottom: CGFloat) -> PinLayoutObjC {
+        impl?.margin(top, horizontal, bottom)
+        return self
+    }
+    
+    public func margin(top: CGFloat, left: CGFloat, bottom: CGFloat, right: CGFloat) -> PinLayoutObjC {
+        impl?.margin(top, left, bottom, right)
+        return self
+    }
+    
+    public func pinEdges() -> PinLayoutObjC {
+        impl?.pinEdges()
+        return self
+    }
+}
+
+#endif

--- a/Sources/PinLayout.swift
+++ b/Sources/PinLayout.swift
@@ -70,11 +70,11 @@ public extension UIView {
  */
 
 /// UIViews's anchor definition
-public protocol Anchor {
+@objc public protocol Anchor {
 }
 
 /// UIViews's list of anchors.
-public protocol AnchorList {
+@objc public protocol AnchorList {
     var topLeft: Anchor { get }
     var topCenter: Anchor { get }
     var topRight: Anchor { get }
@@ -111,7 +111,7 @@ public protocol AnchorList {
 */
 
 /// UIViews's list of edges
-public protocol EdgeList {
+@objc public protocol EdgeList {
     var top: VerticalEdge { get }
     var vCenter: VerticalEdge { get }
     var bottom: VerticalEdge { get }
@@ -416,7 +416,7 @@ public protocol PinLayout {
 /// - left: left aligned
 /// - center: center aligned
 /// - right: right aligned
-public enum HorizontalAlign: String {
+@objc public enum HorizontalAlign: Int {
     case left
     case center
     case right
@@ -431,19 +431,18 @@ public enum HorizontalAlign: String {
 /// - top: top aligned
 /// - center: center aligned
 /// - bottom: bottom aligned
-public enum VerticalAlign: String {
+@objc public enum VerticalAlign: Int {
     case top
     case center
     case bottom
 }
 
 /// UIView's horizontal edges (left/right) definition
-public protocol HorizontalEdge {
+@objc public protocol HorizontalEdge {
 }
 
 /// UIView's vertical edges (top/bottom) definition
-public protocol VerticalEdge {
+@objc public protocol VerticalEdge {
 }
-
         
 #endif

--- a/Sources/PinLayoutImpl+Relative.swift
+++ b/Sources/PinLayoutImpl+Relative.swift
@@ -31,6 +31,7 @@ extension PinLayoutImpl {
         return above(relativeViews: [relativeView], aligned: aligned, context: context)
     }
     
+    @discardableResult
     func above(of relativeViews: [UIView], aligned: HorizontalAlign) -> PinLayout {
         func context() -> String { return "above(of: \(relativeViews), aligned: \(aligned))" }
         return above(relativeViews: relativeViews, aligned: aligned, context: context)

--- a/Sources/PinLayoutImpl+Warning.swift
+++ b/Sources/PinLayoutImpl+Warning.swift
@@ -60,7 +60,7 @@ extension PinLayoutImpl {
     
     internal func displayLayoutWarnings() {
         if let justify = justify {
-            func context() -> String { return "justify(.\(justify))" }
+            func context() -> String { return "justify(.\(justify.description))" }
             if !((_left != nil && _right != nil) || (shouldPinEdges && width != nil && (_left != nil || _right != nil || _hCenter != nil))) {
                 warnWontBeApplied("the left and right coordinates must be set to justify the view horizontally.", context)
             }
@@ -71,7 +71,7 @@ extension PinLayoutImpl {
         }
         
         if let align = align {
-            func context() -> String { return "align(.\(align))" }
+            func context() -> String { return "align(.\(align.description))" }
             if !((_top != nil && _bottom != nil) || (shouldPinEdges && height != nil && (_top != nil || _bottom != nil || _vCenter != nil))) {
                 warnWontBeApplied("the top and bottom coordinates must be set to align the view vertically.", context)
             }

--- a/Sources/TypesImpl.swift
+++ b/Sources/TypesImpl.swift
@@ -33,7 +33,28 @@ import UIKit
 typealias Context = () -> String
 typealias Size = (width: CGFloat?, height: CGFloat?)
 
+extension HorizontalAlign {
+    var description: String {
+        switch self {
+        case .left: return "left"
+        case .center: return "center"
+        case .right: return "right"
+        case .start: return "start"
+        case .end: return "end"
+        }
+    }
+}
 
+extension VerticalAlign {
+    var description: String {
+        switch self {
+        case .top: return "top"
+        case .center: return "center"
+        case .bottom: return "bottom"
+        }
+    }
+}
+    
 class EdgeListImpl: EdgeList {
     internal let view: UIView
 
@@ -164,7 +185,7 @@ class AnchorImpl: Anchor {
     }
 }
 
-extension Percent: CustomStringConvertible {
+extension Percent {
     func of(_ rhs: CGFloat) -> CGFloat {
         return rhs * value / 100
     }

--- a/docs/objective_c.md
+++ b/docs/objective_c.md
@@ -1,0 +1,48 @@
+<p align="center">
+	<img src="pinlayout-logo-small.png" width=100/>
+</p>
+
+<h1 align="center" style="color: #376C9D; font-family: Arial Black, Gadget, sans-serif; font-size: 1.5em">PinLayout Objective-C</h1>
+
+PinLayout can also be used from Objective-C. The PinLayout interface is slightly different from the Swift interface due to more limited objective-c parameter definitions.
+
+###### Example 1:
+This example implement the PinLayout's Intro example using objective-c 
+
+<a href="https://github.com/mirego/PinLayout/blob/master/Example/PinLayoutSample/UI/Examples/Intro/IntroView.swift"><img src="pinlayout-intro-example.png"/></a>
+
+```
+- (void) layoutSubviews {
+    [super layoutSubviews];
+    
+    [[[[[[logo.pinObjc top] left] width:100] aspectRatio] marginWithTop:topLayoutGuide + 10 horizontal:10 bottom:10] layout];
+    [[[[segmented.pinObjc rightOf:logo aligned:VerticalAlignTop] right] marginHorizontal:10] layout];
+    [[[[[[textLabel.pinObjc belowOf:segmented aligned:HorizontalAlignLeft] widthOf:segmented] pinEdges] marginTop:10] fitSize] layout];
+    [[[[[separatorView.pinObjc belowOfViews:@[logo, textLabel] aligned:HorizontalAlignLeft] rightTo:segmented.edge.right] height:1] marginTop:10] layout];
+}
+
+``` 
+
+:pushpin: This example is available in the Examples App. See example complete [source code](https://github.com/mirego/PinLayout/blob/master/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCView.m)
+
+## Important notes about PinLayout's Objective-c interface
+
+#### `pinObjc` property
+The PinLayout's objective-c interface is available using the property `pinObjc` (instead of `pin` in Swift)
+
+```
+ [[view.pinObjc top] layout];
+``` 
+
+#### `layout` method
+
+When using the Objective-c interface, the `layout` method must be called explicitly to complete the view's layout. 
+
+```
+ // Swift
+ view.pin.width(100)
+
+ // Objective-c
+ [[view.pinObjc width:100] layout];
+``` 
+


### PR DESCRIPTION
Add an PinLayout Objective-c interface
The interface is slightly different from the Swift interface.

Major differences:
* The PinLayout's objective-c interface is available using the property `pinObjc` (instead of `pin` in Swift)
* When using the Objective-c interface, the `layout` method must be called explicitly to complete the view's layout.

Plus:
* Add an Objective-c implementation of the PinLayout's Intro example.
f1f2832
