### PR TITLE
PinLayout now applies margins when hCenter or vCenter have been set.

### DIFF
--- a/PinLayout.podspec
+++ b/PinLayout.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "PinLayout"
-  s.version      = "1.3.4"
+  s.version      = "1.4.0"
   s.summary      = "Fast Swift UIViews layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable."
   s.description  = "Fast Swift UIViews layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable."
 

--- a/Sources/PinLayoutImpl.swift
+++ b/Sources/PinLayoutImpl.swift
@@ -930,7 +930,7 @@ extension PinLayoutImpl {
         } else if let _hCenter = _hCenter, let width = newSize.width {
             // hCenter & width is set
             newRect.size.width = width
-            newRect.origin.x = (_hCenter - (width / 2)) + _marginLeft
+            newRect.origin.x = (_hCenter - (width / 2)) + _marginLeft - _marginRight
         } else if let left = _left {
             // Only left is set
             newRect.origin.x = left + _marginLeft
@@ -939,7 +939,7 @@ extension PinLayoutImpl {
             newRect.origin.x = right - view.frame.width - _marginRight
         } else if let _hCenter = _hCenter {
             // Only hCenter is set
-            newRect.origin.x = (_hCenter - (view.frame.width / 2)) + _marginLeft
+            newRect.origin.x = (_hCenter - (view.frame.width / 2)) + _marginLeft - _marginRight
         } else if let width = newSize.width {
             // Only width is set
             newRect.size.width = width
@@ -966,7 +966,7 @@ extension PinLayoutImpl {
         } else if let _vCenter = _vCenter, let height = newSize.height {
             // vCenter & height is set
             newRect.size.height = height
-            newRect.origin.y = (_vCenter - (height / 2)) + _marginTop
+            newRect.origin.y = (_vCenter - (height / 2)) + _marginTop - _marginBottom
         } else if let top = _top {
             // Only top is set
             newRect.origin.y = top + _marginTop
@@ -975,7 +975,7 @@ extension PinLayoutImpl {
             newRect.origin.y = bottom - view.frame.height - _marginBottom
         } else if let _vCenter = _vCenter {
             // Only vCenter is set
-            newRect.origin.y = (_vCenter - (view.frame.height / 2)) + _marginTop
+            newRect.origin.y = (_vCenter - (view.frame.height / 2)) + _marginTop - _marginBottom
         } else if let height = newSize.height {
             // Only height is set
             newRect.size.height = height

--- a/Sources/PinLayoutImpl.swift
+++ b/Sources/PinLayoutImpl.swift
@@ -930,7 +930,7 @@ extension PinLayoutImpl {
         } else if let _hCenter = _hCenter, let width = newSize.width {
             // hCenter & width is set
             newRect.size.width = width
-            newRect.origin.x = _hCenter - (width / 2)
+            newRect.origin.x = (_hCenter - (width / 2)) + _marginLeft
         } else if let left = _left {
             // Only left is set
             newRect.origin.x = left + _marginLeft
@@ -939,7 +939,7 @@ extension PinLayoutImpl {
             newRect.origin.x = right - view.frame.width - _marginRight
         } else if let _hCenter = _hCenter {
             // Only hCenter is set
-            newRect.origin.x = _hCenter - (view.frame.width / 2)
+            newRect.origin.x = (_hCenter - (view.frame.width / 2)) + _marginLeft
         } else if let width = newSize.width {
             // Only width is set
             newRect.size.width = width
@@ -966,7 +966,7 @@ extension PinLayoutImpl {
         } else if let _vCenter = _vCenter, let height = newSize.height {
             // vCenter & height is set
             newRect.size.height = height
-            newRect.origin.y = _vCenter - (height / 2)
+            newRect.origin.y = (_vCenter - (height / 2)) + _marginTop
         } else if let top = _top {
             // Only top is set
             newRect.origin.y = top + _marginTop
@@ -975,7 +975,7 @@ extension PinLayoutImpl {
             newRect.origin.y = bottom - view.frame.height - _marginBottom
         } else if let _vCenter = _vCenter {
             // Only vCenter is set
-            newRect.origin.y = _vCenter - (view.frame.height / 2)
+            newRect.origin.y = (_vCenter - (view.frame.height / 2)) + _marginTop
         } else if let height = newSize.height {
             // Only height is set
             newRect.size.height = height

--- a/Tests/MarginsSpec.swift
+++ b/Tests/MarginsSpec.swift
@@ -413,12 +413,22 @@ class MarginsSpec: QuickSpec {
         describe("the result of top&bottom margins when the hCenter is specified") {
             it("should adjust the aView") {
                 aView.pin.hCenter(100).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 210.0, y: 100.0, width: 200.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 200.0, y: 100.0, width: 200.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
+                aView.pin.hCenter(100).marginLeft(10)
+                expect(aView.frame).to(equal(CGRect(x: 210.0, y: 100.0, width: 200.0, height: 120.0)))
+            }
+
+            it("should adjust the aView") {
+                aView.pin.hCenter(100).marginRight(10)
+                expect(aView.frame).to(equal(CGRect(x: 190.0, y: 100.0, width: 200.0, height: 120.0)))
+            }
+
+            it("should adjust the aView") {
                 aView.pin.hCenter(-100).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 10.0, y: 100.0, width: 200.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 200.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
@@ -452,7 +462,7 @@ class MarginsSpec: QuickSpec {
             
             it("should adjust the aView") {
                 aView.pin.hCenter(100).width(50).height(100).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 285.0, y: 100.0, width: 50.0, height: 100.0)))
+                expect(aView.frame).to(equal(CGRect(x: 275.0, y: 100.0, width: 50.0, height: 100.0)))
             }
 
             it("should adjust the aView") {
@@ -477,17 +487,22 @@ class MarginsSpec: QuickSpec {
         describe("the result of top&bottom margins when the vCenter is specified") {
             it("should adjust the aView") {
                 aView.pin.vCenter(100).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 250.0, width: 200.0, height: 120.0)))
-            }
-            
-            it("should adjust the aView") {
-                aView.pin.vCenter(100).height(100).pinEdges().margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 260.0, width: 200.0, height: 80.0)))
+                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 240.0, width: 200.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.vCenter(100).marginTop(10)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 250.0, width: 200.0, height: 120.0)))
+            }
+
+            it("should adjust the aView") {
+                aView.pin.vCenter(100).marginBottom(10)
+                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 230.0, width: 200.0, height: 120.0)))
+            }
+
+            it("should adjust the aView") {
+                aView.pin.vCenter(100).height(100).pinEdges().margin(10)
+                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 260.0, width: 200.0, height: 80.0)))
             }
             
             it("should adjust the aView") {
@@ -511,7 +526,7 @@ class MarginsSpec: QuickSpec {
             }
             it("should adjust the aView") {
                 aView.pin.vCenter(50%).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 350.0, width: 200.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 340.0, width: 200.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
@@ -526,7 +541,7 @@ class MarginsSpec: QuickSpec {
         describe("the result of top&bottom margins when the hCenter and vCenter are specified") {
             it("should adjust the aView") {
                 aView.pin.hCenter(100).vCenter(100).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 210.0, y: 250.0, width: 200.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 200.0, y: 240.0, width: 200.0, height: 120.0)))
             }
             
             it("should adjust the aView") {

--- a/Tests/MarginsSpec.swift
+++ b/Tests/MarginsSpec.swift
@@ -413,12 +413,12 @@ class MarginsSpec: QuickSpec {
         describe("the result of top&bottom margins when the hCenter is specified") {
             it("should adjust the aView") {
                 aView.pin.hCenter(100).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 200.0, y: 100.0, width: 200.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 210.0, y: 100.0, width: 200.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.hCenter(-100).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 200.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 10.0, y: 100.0, width: 200.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
@@ -452,7 +452,7 @@ class MarginsSpec: QuickSpec {
             
             it("should adjust the aView") {
                 aView.pin.hCenter(100).width(50).height(100).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 275.0, y: 100.0, width: 50.0, height: 100.0)))
+                expect(aView.frame).to(equal(CGRect(x: 285.0, y: 100.0, width: 50.0, height: 100.0)))
             }
 
             it("should adjust the aView") {
@@ -477,7 +477,7 @@ class MarginsSpec: QuickSpec {
         describe("the result of top&bottom margins when the vCenter is specified") {
             it("should adjust the aView") {
                 aView.pin.vCenter(100).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 240.0, width: 200.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 250.0, width: 200.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
@@ -487,7 +487,7 @@ class MarginsSpec: QuickSpec {
             
             it("should adjust the aView") {
                 aView.pin.vCenter(100).marginTop(10)
-                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 240.0, width: 200.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 250.0, width: 200.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
@@ -511,7 +511,7 @@ class MarginsSpec: QuickSpec {
             }
             it("should adjust the aView") {
                 aView.pin.vCenter(50%).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 340.0, width: 200.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 140.0, y: 350.0, width: 200.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
@@ -526,12 +526,12 @@ class MarginsSpec: QuickSpec {
         describe("the result of top&bottom margins when the hCenter and vCenter are specified") {
             it("should adjust the aView") {
                 aView.pin.hCenter(100).vCenter(100).margin(10)
-                expect(aView.frame).to(equal(CGRect(x: 200.0, y: 240.0, width: 200.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 210.0, y: 250.0, width: 200.0, height: 120.0)))
             }
             
             it("should adjust the aView") {
                 aView.pin.hCenter(100).vCenter(100).width(100).pinEdges().marginTop(10)
-                expect(aView.frame).to(equal(CGRect(x: 250.0, y: 240.0, width: 100.0, height: 120.0)))
+                expect(aView.frame).to(equal(CGRect(x: 250.0, y: 250.0, width: 100.0, height: 120.0)))
             }
             
             it("should adjust the aView") {

--- a/Tests/RelativePositionMultipleViewsSpec.swift
+++ b/Tests/RelativePositionMultipleViewsSpec.swift
@@ -188,7 +188,7 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             
             it("should move the view below relative views") {
                 bViewChild.pin.below(of: [aView, bView], aligned: .center).margin(10)
-                expect(bViewChild.frame).to(equal(CGRect(x: -37.5, y: 90.0, width: 60.0, height: 20.0)))
+                expect(bViewChild.frame).to(equal(CGRect(x: -27.5, y: 90.0, width: 60.0, height: 20.0)))
             }
         }
         
@@ -243,7 +243,7 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             
             it("should move the view left relative views") {
                 bViewChild.pin.left(of: [aView, bView], aligned: .center).margin(10)
-                expect(bViewChild.frame).to(equal(CGRect(x: -190.0, y: 15.0, width: 60.0, height: 20.0)))
+                expect(bViewChild.frame).to(equal(CGRect(x: -190.0, y: 25.0, width: 60.0, height: 20.0)))
             }
         }
         
@@ -293,7 +293,7 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             
             it("should move the view right relative views") {
                 bViewChild.pin.right(of: [aView, bView], aligned: .center).margin(10)
-                expect(bViewChild.frame).to(equal(CGRect(x: 120.0, y: 15.0, width: 60.0, height: 20.0)))
+                expect(bViewChild.frame).to(equal(CGRect(x: 120.0, y: 25.0, width: 60.0, height: 20.0)))
             }
         }     
     }

--- a/Tests/RelativePositionMultipleViewsSpec.swift
+++ b/Tests/RelativePositionMultipleViewsSpec.swift
@@ -188,7 +188,17 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             
             it("should move the view below relative views") {
                 bViewChild.pin.below(of: [aView, bView], aligned: .center).margin(10)
-                expect(bViewChild.frame).to(equal(CGRect(x: -27.5, y: 90.0, width: 60.0, height: 20.0)))
+                expect(bViewChild.frame).to(equal(CGRect(x: -37.5, y: 90.0, width: 60.0, height: 20.0)))
+            }
+            
+            it("should move the view below relative views") {
+                bViewChild.pin.below(of: [aView, bView], aligned: .center).marginLeft(10)
+                expect(bViewChild.frame).to(equal(CGRect(x: -27.5, y: 80.0, width: 60.0, height: 20.0)))
+            }
+            
+            it("should move the view below relative views") {
+                bViewChild.pin.below(of: [aView, bView], aligned: .center).marginRight(10)
+                expect(bViewChild.frame).to(equal(CGRect(x: -47.5, y: 80.0, width: 60.0, height: 20.0)))
             }
         }
         
@@ -243,7 +253,17 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             
             it("should move the view left relative views") {
                 bViewChild.pin.left(of: [aView, bView], aligned: .center).margin(10)
-                expect(bViewChild.frame).to(equal(CGRect(x: -190.0, y: 25.0, width: 60.0, height: 20.0)))
+                expect(bViewChild.frame).to(equal(CGRect(x: -190.0, y: 15.0, width: 60.0, height: 20.0)))
+            }
+
+            it("should move the view left relative views") {
+                bViewChild.pin.left(of: [aView, bView], aligned: .center).marginTop(10)
+                expect(bViewChild.frame).to(equal(CGRect(x: -180.0, y: 25.0, width: 60.0, height: 20.0)))
+            }
+            
+            it("should move the view left relative views") {
+                bViewChild.pin.left(of: [aView, bView], aligned: .center).marginBottom(10)
+                expect(bViewChild.frame).to(equal(CGRect(x: -180.0, y: 5.0, width: 60.0, height: 20.0)))
             }
         }
         
@@ -293,8 +313,18 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
             
             it("should move the view right relative views") {
                 bViewChild.pin.right(of: [aView, bView], aligned: .center).margin(10)
-                expect(bViewChild.frame).to(equal(CGRect(x: 120.0, y: 25.0, width: 60.0, height: 20.0)))
+                expect(bViewChild.frame).to(equal(CGRect(x: 120.0, y: 15.0, width: 60.0, height: 20.0)))
             }
-        }     
+
+            it("should move the view right relative views") {
+                bViewChild.pin.right(of: [aView, bView], aligned: .center).marginTop(10)
+                expect(bViewChild.frame).to(equal(CGRect(x: 110.0, y: 25.0, width: 60.0, height: 20.0)))
+            }
+            
+            it("should move the view right relative views") {
+                bViewChild.pin.right(of: [aView, bView], aligned: .center).marginBottom(10)
+                expect(bViewChild.frame).to(equal(CGRect(x: 110.0, y: 5.0, width: 60.0, height: 20.0)))
+            }
+        }
     }
 }


### PR DESCRIPTION
PinLayout now apply correctly margins when `hCenter` or `vCenter` have been set
* hCenter: When the Horizontal Center is set, PinLayout now applies the left margin.
* vCenter: When the Vertical Center is set, PinLayout now applies the top margin.

BREAKING CHANGE: This may be a breaking change if you are using `hCenter(..)`, `vCenter(...)`, `center(...)`, `centerRight(...)`, `centerLeft(...)`, or any other method using the center position *while also using a margin*.