### PR TITLE
Add layout() method to support Xcode playgrounds.

### DIFF
--- a/Example/PinLayoutSample/UI/Examples/AutoAdjustingSizeView/AutoAdjustingSizeView.swift
+++ b/Example/PinLayoutSample/UI/Examples/AutoAdjustingSizeView/AutoAdjustingSizeView.swift
@@ -82,7 +82,7 @@ class AutoAdjustingSizeView: BaseView {
         row1Item2.pin.right(of: row1Item1, aligned: .top).bottomRight().margin(0, 2, 2, 2)
 
         row2.pin.below(of: row1, aligned: .left).size(of: row1).marginTop(10)
-        row2Item1.pin.top().right().bottom().width(150).width(25%).margin(2)
+        row2Item1.pin.top().bottom().right().width(150).margin(2)
         row2Item2.pin.left(of: row2Item1, aligned: .top).left().bottom().margin(0, 2, 2, 2)
 
         row3.pin.below(of: row2, aligned: .left).size(of: row1).marginTop(10)

--- a/Example/PinLayoutSample/UI/Examples/Intro/IntroView.swift
+++ b/Example/PinLayoutSample/UI/Examples/Intro/IntroView.swift
@@ -62,7 +62,7 @@ class IntroView: BaseView {
         let containerInsets = safeArea.minInsets(UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10))
         contentView.pin.all().margin(containerInsets)
         
-        logo.pin.top().left().size(100).aspectRatio().marginTop(10)
+        logo.pin.top().left().width(100).aspectRatio().marginTop(10)
         segmented.pin.after(of: logo, aligned: .top).right().marginLeft(10)
         textLabel.pin.below(of: segmented, aligned: .left).width(of: segmented).pinEdges().marginTop(10).sizeToFit(.width)
         separatorView.pin.below(of: [logo, textLabel], aligned: .left).right(to: segmented.edge.right).marginTop(10)

--- a/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCView.m
+++ b/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCView.m
@@ -32,6 +32,8 @@
 
 - (id)initWithFrame:(CGRect)frame {
     if ((self = [super initWithFrame:frame])) {
+        Pin.logMissingLayoutCalls = true;
+        
         topLayoutGuide = 0;
         self.backgroundColor = UIColor.whiteColor;
         
@@ -54,6 +56,10 @@
         [self addSubview:separatorView];
     }
     return self;
+}
+
+- (void)dealloc {
+    Pin.logMissingLayoutCalls = false;
 }
 
 - (void) layoutSubviews {

--- a/Example/PinLayoutSample/UI/Examples/IntroRTL/IntroRTLView.swift
+++ b/Example/PinLayoutSample/UI/Examples/IntroRTL/IntroRTLView.swift
@@ -67,7 +67,7 @@ class IntroRTLView: BaseView {
         let containerInsets = safeArea.minInsets(UIEdgeInsets(top: 10, left: 10, bottom: 0, right: 10))
         contentView.pin.all().margin(containerInsets)
 
-        logo.pin.top().start().size(100).aspectRatio().marginTop(10)
+        logo.pin.top().start().width(100).aspectRatio().marginTop(10)
         segmented.pin.after(of: logo, aligned: .top).end().marginStart(10)
         textLabel.pin.below(of: segmented, aligned: .start).width(of: segmented).pinEdges().marginTop(10).sizeToFit(.width)
         separatorView.pin.below(of: [logo, textLabel], aligned: .start).end(to: segmented.edge.end).marginTop(10)

--- a/PinLayout.xcodeproj/project.pbxproj
+++ b/PinLayout.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		242723731F008BF7006A5C3A /* MinMaxWidthHeightSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 242723711F008B85006A5C3A /* MinMaxWidthHeightSpec.swift */; };
 		242E8DC31EED5AB2005935FB /* RelativePositionMultipleViewsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 242E8DC11EED5982005935FB /* RelativePositionMultipleViewsSpec.swift */; };
 		243B12BC1FC393580072A9C3 /* Percent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C620E1FC3834B0082C327 /* Percent.swift */; };
+		243B12C81FC3D06F0072A9C3 /* LayoutMethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243B12C41FC3CFC10072A9C3 /* LayoutMethodSpec.swift */; };
 		243C62041FC37F680082C327 /* PinLayoutImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2475B6C61FC37C1C0054CADD /* PinLayoutImpl.swift */; };
 		243C62051FC37F6C0082C327 /* PinLayoutImpl+Coordinates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2475B6C71FC37C1C0054CADD /* PinLayoutImpl+Coordinates.swift */; };
 		243C62061FC37F6C0082C327 /* PinLayoutImpl+Layouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2475B6C41FC37A900054CADD /* PinLayoutImpl+Layouting.swift */; };
@@ -86,6 +87,7 @@
 		241A277C1F8E958F00B1AD39 /* PinLayoutObjCImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinLayoutObjCImpl.swift; sourceTree = "<group>"; };
 		242723711F008B85006A5C3A /* MinMaxWidthHeightSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MinMaxWidthHeightSpec.swift; sourceTree = "<group>"; };
 		242E8DC11EED5982005935FB /* RelativePositionMultipleViewsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelativePositionMultipleViewsSpec.swift; sourceTree = "<group>"; };
+		243B12C41FC3CFC10072A9C3 /* LayoutMethodSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutMethodSpec.swift; sourceTree = "<group>"; };
 		243C620E1FC3834B0082C327 /* Percent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Percent.swift; path = Impl/Percent.swift; sourceTree = "<group>"; };
 		244C6E141E776A0C0074FC74 /* MarginsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarginsSpec.swift; sourceTree = "<group>"; };
 		244DF2F81EF46C500090508B /* PinLayoutTVOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PinLayoutTVOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -221,6 +223,7 @@
 				2469C4FF1E75D74000073BEE /* AdjustSizeSpec.swift */,
 				248E4C721F7A83FA00C0E7F7 /* AspectRatioTests.swift */,
 				240F88BC1F0C042500280FC8 /* JustifyAlignSpec.swift */,
+				243B12C41FC3CFC10072A9C3 /* LayoutMethodSpec.swift */,
 				244C6E141E776A0C0074FC74 /* MarginsSpec.swift */,
 				242723711F008B85006A5C3A /* MinMaxWidthHeightSpec.swift */,
 				249EFE881E64FB4C00165E39 /* PinLayoutTests.swift */,
@@ -510,6 +513,7 @@
 			files = (
 				240F88BE1F0C066800280FC8 /* JustifyAlignSpec.swift in Sources */,
 				2469C5001E75D74000073BEE /* AdjustSizeSpec.swift in Sources */,
+				243B12C81FC3D06F0072A9C3 /* LayoutMethodSpec.swift in Sources */,
 				2482908C1E78CFFC00667D08 /* RelativePositionSpec.swift in Sources */,
 				248E4C741F7A883800C0E7F7 /* AspectRatioTests.swift in Sources */,
 				240F88C11F0C1F5000280FC8 /* WarningSpec.swift in Sources */,

--- a/PinLayout.xcodeproj/project.pbxproj
+++ b/PinLayout.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		242E8DC31EED5AB2005935FB /* RelativePositionMultipleViewsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 242E8DC11EED5982005935FB /* RelativePositionMultipleViewsSpec.swift */; };
 		243B12BC1FC393580072A9C3 /* Percent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C620E1FC3834B0082C327 /* Percent.swift */; };
 		243B12C81FC3D06F0072A9C3 /* LayoutMethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243B12C41FC3CFC10072A9C3 /* LayoutMethodSpec.swift */; };
+		243B12CB1FC469D00072A9C3 /* ObjectiveCSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 243B12C91FC469550072A9C3 /* ObjectiveCSpec.m */; };
 		243C62041FC37F680082C327 /* PinLayoutImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2475B6C61FC37C1C0054CADD /* PinLayoutImpl.swift */; };
 		243C62051FC37F6C0082C327 /* PinLayoutImpl+Coordinates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2475B6C71FC37C1C0054CADD /* PinLayoutImpl+Coordinates.swift */; };
 		243C62061FC37F6C0082C327 /* PinLayoutImpl+Layouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2475B6C41FC37A900054CADD /* PinLayoutImpl+Layouting.swift */; };
@@ -51,8 +52,8 @@
 		24BBE6351F50FA1D0091D5E9 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BBE6341F50FA1D0091D5E9 /* UnitTests.swift */; };
 		24BBE6381F52EC380091D5E9 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BBE6341F50FA1D0091D5E9 /* UnitTests.swift */; };
 		24D18D171F3B4381008129EF /* RTLSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D18D151F3B42E0008129EF /* RTLSpec.swift */; };
-		24D18D241F3E37DD008129EF /* PinLayoutGlobals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D18D231F3E37DD008129EF /* PinLayoutGlobals.swift */; };
-		24D18D261F3E5EA5008129EF /* PinLayoutGlobals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D18D231F3E37DD008129EF /* PinLayoutGlobals.swift */; };
+		24D18D241F3E37DD008129EF /* Pin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D18D231F3E37DD008129EF /* Pin.swift */; };
+		24D18D261F3E5EA5008129EF /* Pin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D18D231F3E37DD008129EF /* Pin.swift */; };
 		CA6C7C85508320B18B1FC777 /* Pods_PinLayoutTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45CE7ABE76F48416DE57DF55 /* Pods_PinLayoutTests.framework */; };
 		DF7A36BD1E918301000F9856 /* PinEdgesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7A36BC1E918301000F9856 /* PinEdgesSpec.swift */; };
 		DFC97CA71E8A8F2C001545D5 /* PinLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFC97CA61E8A8F2C001545D5 /* PinLayout.swift */; };
@@ -88,6 +89,7 @@
 		242723711F008B85006A5C3A /* MinMaxWidthHeightSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MinMaxWidthHeightSpec.swift; sourceTree = "<group>"; };
 		242E8DC11EED5982005935FB /* RelativePositionMultipleViewsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelativePositionMultipleViewsSpec.swift; sourceTree = "<group>"; };
 		243B12C41FC3CFC10072A9C3 /* LayoutMethodSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutMethodSpec.swift; sourceTree = "<group>"; };
+		243B12C91FC469550072A9C3 /* ObjectiveCSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectiveCSpec.m; sourceTree = "<group>"; };
 		243C620E1FC3834B0082C327 /* Percent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Percent.swift; path = Impl/Percent.swift; sourceTree = "<group>"; };
 		244C6E141E776A0C0074FC74 /* MarginsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarginsSpec.swift; sourceTree = "<group>"; };
 		244DF2F81EF46C500090508B /* PinLayoutTVOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PinLayoutTVOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -118,7 +120,7 @@
 		249EFE8A1E64FB4C00165E39 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		24BBE6341F50FA1D0091D5E9 /* UnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UnitTests.swift; path = Impl/UnitTests.swift; sourceTree = "<group>"; };
 		24D18D151F3B42E0008129EF /* RTLSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RTLSpec.swift; sourceTree = "<group>"; };
-		24D18D231F3E37DD008129EF /* PinLayoutGlobals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinLayoutGlobals.swift; sourceTree = "<group>"; };
+		24D18D231F3E37DD008129EF /* Pin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pin.swift; sourceTree = "<group>"; };
 		45CE7ABE76F48416DE57DF55 /* Pods_PinLayoutTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PinLayoutTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		561BC8B0591ACB691B563927 /* Pods-PinLayoutTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PinLayoutTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PinLayoutTests/Pods-PinLayoutTests.release.xcconfig"; sourceTree = "<group>"; };
 		6070E55EDEAA3DC58C0B4CDD /* Pods-PinLayoutTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PinLayoutTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PinLayoutTests/Pods-PinLayoutTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -207,7 +209,7 @@
 			children = (
 				DFC97CA61E8A8F2C001545D5 /* PinLayout.swift */,
 				24949A2D1EF69474003643D3 /* PinLayout+Filters.swift */,
-				24D18D231F3E37DD008129EF /* PinLayoutGlobals.swift */,
+				24D18D231F3E37DD008129EF /* Pin.swift */,
 				DFA06B031E8B38B300B6D5E7 /* Impl */,
 				241A277A1F8E958F00B1AD39 /* ObjectiveC */,
 				2475B6D51FC37D270054CADD /* SupportingFiles */,
@@ -226,6 +228,7 @@
 				243B12C41FC3CFC10072A9C3 /* LayoutMethodSpec.swift */,
 				244C6E141E776A0C0074FC74 /* MarginsSpec.swift */,
 				242723711F008B85006A5C3A /* MinMaxWidthHeightSpec.swift */,
+				243B12C91FC469550072A9C3 /* ObjectiveCSpec.m */,
 				249EFE881E64FB4C00165E39 /* PinLayoutTests.swift */,
 				DF7A36BC1E918301000F9856 /* PinEdgesSpec.swift */,
 				2469C4FB1E74855D00073BEE /* PinEdgeCoordinateSpec.swift */,
@@ -362,7 +365,7 @@
 					};
 					249EFE791E64FB4C00165E39 = {
 						CreatedOnToolsVersion = 8.2.1;
-						LastSwiftMigration = 0820;
+						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
 					249EFE821E64FB4C00165E39 = {
@@ -470,7 +473,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				243C62081FC37F6C0082C327 /* PinLayoutImpl+Warning.swift in Sources */,
-				24D18D261F3E5EA5008129EF /* PinLayoutGlobals.swift in Sources */,
+				24D18D261F3E5EA5008129EF /* Pin.swift in Sources */,
 				243C62041FC37F680082C327 /* PinLayoutImpl.swift in Sources */,
 				243C62071FC37F6C0082C327 /* PinLayoutImpl+Relative.swift in Sources */,
 				243B12BC1FC393580072A9C3 /* Percent.swift in Sources */,
@@ -489,7 +492,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				24D18D241F3E37DD008129EF /* PinLayoutGlobals.swift in Sources */,
+				24D18D241F3E37DD008129EF /* Pin.swift in Sources */,
 				2475B6CA1FC37C1C0054CADD /* PinLayoutImpl.swift in Sources */,
 				241A277E1F8E958F00B1AD39 /* PinLayoutObjCImpl.swift in Sources */,
 				243C620F1FC3834B0082C327 /* Percent.swift in Sources */,
@@ -515,6 +518,7 @@
 				2469C5001E75D74000073BEE /* AdjustSizeSpec.swift in Sources */,
 				243B12C81FC3D06F0072A9C3 /* LayoutMethodSpec.swift in Sources */,
 				2482908C1E78CFFC00667D08 /* RelativePositionSpec.swift in Sources */,
+				243B12CB1FC469D00072A9C3 /* ObjectiveCSpec.m in Sources */,
 				248E4C741F7A883800C0E7F7 /* AspectRatioTests.swift in Sources */,
 				240F88C11F0C1F5000280FC8 /* WarningSpec.swift in Sources */,
 				242E8DC31EED5AB2005935FB /* RelativePositionMultipleViewsSpec.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Extremely Fast views layouting without auto layout. No magic, pure code, full co
   * [Warnings](#warnings)
   * [More examples](#more_examples)
 * [Examples App](#examples_app)
+* [Using PinLayout with Xcode Playgrounds](#playgrounds)
 * [Using PinLayout with Objective-C](#objective_c_interface)
 * [Installation](#installation)
 * [FAQ](#faq)
@@ -81,7 +82,7 @@ This example layout an image, a UISegmentedControl, a label and a line separator
 override func layoutSubviews() {
    super.layoutSubviews() 
     
-   logo.pin.top().left().size(100).aspectRatio().margin(10)
+   logo.pin.top().left().width(100).aspectRatio().margin(10)
    segmented.pin.after(of: logo, aligned: .top).right().marginHorizontal(10)
    textLabel.pin.below(of: segmented, aligned: .left).right().marginTop(10).marginRight(10).sizeToFit(.width)
    separatorView.pin.below(of: [logo, textLabel], aligned: .left).right(to: segmented.edge.right).marginTop(10)
@@ -1179,6 +1180,10 @@ Example:
 `view.pin.left().width(250).justify(.center)`  
 👉 PinLayout Warning: justify(center) won't be applied, the left and right coordinates must be set to justify the view.
 
+* Layout must be executed from the **Main thread**.  
+👉 PinLayout Warning: Layout must be executed from the Main Thread!
+
+
 ### Disabling warnings
 
 Warnings can be disabled also in debug mode by setting the boolean Pin.logWarnings to false.
@@ -1334,6 +1339,25 @@ There is an Example app that expose some usage example on PinLayout, including:
 This app is available in the `Example` folder. Note that you must do a `pod install` before running the example project.
 
 <br>
+
+## Using PinLayout with Xcode Playgrounds <a name="playgrounds"></a>
+PinLayout layouts views immediately after the line containing `.pin` has been fully executed, thanks to ARC (Automatic Reference Counting) this works perfectly on iOS/tvOS/macOS simulators and devices. But in Xcode Playgrounds, ARC doesn't work as expected, object references are kept much longer. This is a well documented issue. The impact of this problem is that PinLayout doesn't layout views at the time and in the order required. To handle this situation in playgrounds it is possible to call the `layout()` method to complete the layout.
+
+**Method:**
+
+* **`layout()`**  
+The method will execute PinLayout commands immediately. This method is **required only if your source codes should also works in Xcode Playgrounds**. Outside of playgrounds, PinLayout execute this method implicetely, it is not necessary to call it. 
+
+###### Usage Examples:
+
+```swift
+    view.pin.top(20).bottom(20).width(100).layout()
+    view2.pin.below(of: view).left().right().layout()
+```
+
+**TIP**: If your codes needs to work in Xcode playgrounds, you may set to `true` the property `Pin.warnMissingLayoutCalls`, this way any missing call to `layout()` will generate a warning in the Xcode console.
+
+<br>     
 
 ## Using PinLayout with Objective-C <a name="objective_c_interface"></a>
 PinLayout also expose an Objective-C interface slightly different than the Swift interface. 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Extremely Fast views layouting without auto layout. No magic, pure code, full co
   * [Warnings](#warnings)
   * [More examples](#more_examples)
 * [Examples App](#examples_app)
-* [Using PinLayout with Xcode Playgrounds](#playgrounds)
-* [Using PinLayout with Objective-C](#objective_c_interface)
+* [PinLayout in Xcode Playgrounds](#playgrounds)
+* [PinLayout using Objective-C](#objective_c_interface)
 * [Installation](#installation)
 * [FAQ](#faq)
 * [Comments, ideas, suggestions, issues, ....](#comments)
@@ -1340,29 +1340,18 @@ This app is available in the `Example` folder. Note that you must do a `pod inst
 
 <br>
 
-## Using PinLayout with Xcode Playgrounds <a name="playgrounds"></a>
-PinLayout layouts views immediately after the line containing `.pin` has been fully executed, thanks to ARC (Automatic Reference Counting) this works perfectly on iOS/tvOS/macOS simulators and devices. But in Xcode Playgrounds, ARC doesn't work as expected, object references are kept much longer. This is a well documented issue. The impact of this problem is that PinLayout doesn't layout views at the time and in the order required. To handle this situation in playgrounds it is possible to call the `layout()` method to complete the layout.
+## PinLayout in Xcode Playgrounds <a name="playgrounds"></a>
 
-**Method:**
+PinLayout layouts views immediately after the line containing `.pin` has been fully executed, thanks to ARC (Automatic Reference Counting) this works perfectly on iOS/tvOS/macOS simulators and devices. But in Xcode Playgrounds, ARC doesn't work as expected, object references are kept much longer. This is a well documented issue and have a little impact on the PinLayout behaviour.
 
-* **`layout()`**  
-The method will execute PinLayout commands immediately. This method is **required only if your source codes should also work in Xcode Playgrounds**. Outside of playgrounds, PinLayout executes this method implicitly, it is not necessary to call it. 
+[See here for more details about using PinLayout in Xcode playgrounds](docs/xcode_playground.md)
 
-###### Usage Examples:
+<br>
 
-```swift
-    view.pin.top(20).bottom(20).width(100).layout()
-    view2.pin.below(of: view).left().right().layout()
-```
-
-**TIP**: If your codes needs to work in Xcode playgrounds, you may set to `true` the property `Pin.warnMissingLayoutCalls`, this way any missing call to `layout()` will generate a warning in the Xcode console.
-
-<br>     
-
-## Using PinLayout with Objective-C <a name="objective_c_interface"></a>
+## PinLayout using Objective-C <a name="objective_c_interface"></a>
 PinLayout also expose an Objective-C interface slightly different than the Swift interface. 
 
-[See here for more details](docs/objective_c.md).
+[See here for more details](docs/objective_c.md)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -1346,7 +1346,7 @@ PinLayout layouts views immediately after the line containing `.pin` has been fu
 **Method:**
 
 * **`layout()`**  
-The method will execute PinLayout commands immediately. This method is **required only if your source codes should also works in Xcode Playgrounds**. Outside of playgrounds, PinLayout execute this method implicetely, it is not necessary to call it. 
+The method will execute PinLayout commands immediately. This method is **required only if your source codes should also work in Xcode Playgrounds**. Outside of playgrounds, PinLayout executes this method implicitly, it is not necessary to call it. 
 
 ###### Usage Examples:
 

--- a/Sources/Impl/PinLayoutImpl+Warning.swift
+++ b/Sources/Impl/PinLayoutImpl+Warning.swift
@@ -115,7 +115,7 @@ extension PinLayoutImpl {
         displayText += ", Tag: \(view.tag))\n"
         
         print(displayText)
-        _pinlayoutUnitTestLastWarning = text
+        Pin.lastWarningText = text
     }
     
     internal func viewDescription(_ view: UIView) -> String {

--- a/Sources/Impl/PinLayoutImpl+Warning.swift
+++ b/Sources/Impl/PinLayoutImpl+Warning.swift
@@ -52,19 +52,25 @@ extension PinLayoutImpl {
     
     internal func warnPropertyAlreadySet(_ propertyName: String, propertyValue: CGFloat, _ context: Context) {
         guard Pin.logWarnings else { return }
-        displayWarning("PinLayout Conflict: \(context()) won't be applied since it value has already been set to \(propertyValue).")
+        displayWarning("PinLayout Conflict: \(context()) won't be applied since it value has already been set to \(propertyValue.description).")
     }
     
     internal func warnPropertyAlreadySet(_ propertyName: String, propertyValue: CGSize, _ context: Context) {
         guard Pin.logWarnings else { return }
-        displayWarning("PinLayout Conflict: \(context()) won't be applied since it value has already been set to CGSize(width: \(propertyValue.width), height: \(propertyValue.height)).")
+        displayWarning("PinLayout Conflict: \(context()) won't be applied since it value has already been set to CGSize(width: \(propertyValue.width.description), height: \(propertyValue.height.description)).")
     }
     
     internal func warnConflict(_ context: Context, _ properties: [String: Any]) {
         guard Pin.logWarnings else { return }
         var warning = "PinLayout Conflict: \(context()) won't be applied since it conflicts with the following already set properties:"
         properties.forEach { (property) in
-            warning += "\n \(property.key): \(property.value)"
+            warning += "\n \(property.key): "
+            
+            if let floatValue = property.value as? CGFloat {
+                warning += "\(floatValue.description)"
+            } else {
+                warning += "\(property.value)"
+            }
         }
         
         displayWarning(warning)

--- a/Sources/Impl/PinLayoutImpl+Warning.swift
+++ b/Sources/Impl/PinLayoutImpl+Warning.swift
@@ -71,6 +71,10 @@ extension PinLayoutImpl {
     }
     
     internal func displayLayoutWarnings() {
+        if !Thread.isMainThread {
+            warn("Layout must be executed from the Main Thread!")
+        }
+        
         if let justify = justify {
             func context() -> String { return "justify(.\(justify.description))" }
             if !((_left != nil && _right != nil) || (shouldPinEdges && width != nil && (_left != nil || _right != nil || _hCenter != nil))) {
@@ -96,7 +100,7 @@ extension PinLayoutImpl {
     
     internal func displayWarning(_ text: String) {
         var displayText = "\n👉 \(text)"
-        displayText += "\n   (Layouted view info: Type: \(viewName(view)), Frame: \(view.frame)"
+        displayText += "\n(Layouted view info: Type: \(viewName(view)), Frame: \(view.frame)"
         
         var currentView = view
         var hierarchy: [String] = []

--- a/Sources/Impl/PinLayoutImpl.swift
+++ b/Sources/Impl/PinLayoutImpl.swift
@@ -69,6 +69,9 @@ class PinLayoutImpl: PinLayout {
     }
     
     deinit {
+        if !isLayouted && Pin.warnMissingLayoutCalls {
+            warn("PinLayout commands have been issued without calling the 'layout()' method to complete the layout. (These warnings can be disabled by setting Pin.warnMissingLayoutCalls to false)")
+        }
         apply()
     }
     

--- a/Sources/Impl/PinLayoutImpl.swift
+++ b/Sources/Impl/PinLayoutImpl.swift
@@ -69,8 +69,8 @@ class PinLayoutImpl: PinLayout {
     }
     
     deinit {
-        if !isLayouted && Pin.warnMissingLayoutCalls {
-            warn("PinLayout commands have been issued without calling the 'layout()' method to complete the layout. (These warnings can be disabled by setting Pin.warnMissingLayoutCalls to false)")
+        if !isLayouted && Pin.logMissingLayoutCalls {
+            warn("PinLayout commands have been issued without calling the 'layout()' method to complete the layout. (These warnings can be disabled by setting Pin.logMissingLayoutCalls to false)")
         }
         apply()
     }
@@ -91,7 +91,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func top(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "top(\(percent))" }
+        func context() -> String { return "top(\(percent.description))" }
         guard let layoutSuperview = layoutSuperview(context) else { return self }
         setTop(percent.of(layoutSuperview.frame.height), context)
         return self
@@ -109,7 +109,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func left(_ percent: Percent) -> PinLayout {
-        return left(percent, { return "left(\(percent))" })
+        return left(percent, { return "left(\(percent.description))" })
     }
     
     @discardableResult
@@ -126,7 +126,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func start(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "start(\(percent))" }
+        func context() -> String { return "start(\(percent.description))" }
         return isLTR() ? left(percent, context) : right(percent, context)
     }
     
@@ -141,7 +141,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func bottom(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "bottom(\(percent))" }
+        func context() -> String { return "bottom(\(percent.description))" }
         guard let layoutSuperview = layoutSuperview(context) else { return self }
         bottom(percent.of(layoutSuperview.frame.height), context)
         return self
@@ -158,7 +158,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func right(_ percent: Percent) -> PinLayout {
-        return right(percent, { return "right(\(percent))" })
+        return right(percent, { return "right(\(percent.description))" })
     }
     
     @discardableResult func end() -> PinLayout {
@@ -174,7 +174,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func end(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "end(\(percent))" }
+        func context() -> String { return "end(\(percent.description))" }
         return isLTR() ? right(percent, context) : left(percent, context)
     }
 
@@ -196,7 +196,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func hCenter(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "hCenter(\(percent))" }
+        func context() -> String { return "hCenter(\(percent.description))" }
         guard let layoutSuperview = layoutSuperview(context) else { return self }
         setHorizontalCenter((layoutSuperview.frame.width / 2) + percent.of(layoutSuperview.frame.width), context)
         return self
@@ -220,7 +220,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func vCenter(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "vCenter(\(percent))" }
+        func context() -> String { return "vCenter(\(percent.description))" }
         guard let layoutSuperview = layoutSuperview(context) else { return self }
         setVerticalCenter((layoutSuperview.frame.height / 2) + percent.of(layoutSuperview.frame.height), context)
         return self
@@ -607,7 +607,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func width(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "width(\(percent))" }
+        func context() -> String { return "width(\(percent.description))" }
         guard let layoutSuperview = layoutSuperview(context) else { return self }
         return setWidth(percent.of(layoutSuperview.frame.width), context)
     }
@@ -625,7 +625,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func minWidth(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "minWidth(\(percent))" }
+        func context() -> String { return "minWidth(\(percent.description))" }
         guard let layoutSuperview = layoutSuperview(context) else { return self }
         return setMinWidth(percent.of(layoutSuperview.frame.width), context)
     }
@@ -638,7 +638,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func maxWidth(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "maxWidth(\(percent))" }
+        func context() -> String { return "maxWidth(\(percent.description))" }
         guard let layoutSuperview = layoutSuperview(context) else { return self }
         return setMaxWidth(percent.of(layoutSuperview.frame.width), context)
     }
@@ -650,7 +650,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func height(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "height(\(percent))" }
+        func context() -> String { return "height(\(percent.description))" }
         guard let layoutSuperview = layoutSuperview(context) else { return self }
         return setHeight(percent.of(layoutSuperview.frame.height), context)
     }
@@ -668,7 +668,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func minHeight(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "minHeight(\(percent))" }
+        func context() -> String { return "minHeight(\(percent.description))" }
         guard let layoutSuperview = layoutSuperview(context) else { return self }
         return setMinHeight(percent.of(layoutSuperview.frame.height), context)
     }
@@ -681,7 +681,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func maxHeight(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "maxHeight(\(percent))" }
+        func context() -> String { return "maxHeight(\(percent.description))" }
         guard let layoutSuperview = layoutSuperview(context) else { return self }
         return setMaxHeight(percent.of(layoutSuperview.frame.height), context)
     }
@@ -701,7 +701,7 @@ class PinLayoutImpl: PinLayout {
     
     @discardableResult
     func size(_ percent: Percent) -> PinLayout {
-        func context() -> String { return "size(\(percent))" }
+        func context() -> String { return "size(\(percent.description))" }
         guard let layoutSuperview = layoutSuperview(context) else { return self }
         let size = CGSize(width: percent.of(layoutSuperview.frame.width), height: percent.of(layoutSuperview.frame.height))
         return setSize(size, context)

--- a/Sources/Impl/TypesImpl.swift
+++ b/Sources/Impl/TypesImpl.swift
@@ -182,7 +182,21 @@ extension Percent {
         return rhs * value / 100
     }
     public var description: String {
-        return "\(value)%"
+        if value.truncatingRemainder(dividingBy: 1) == 0.0 {
+            return "\(Int(value))%"
+        } else {
+            return "\(value)%"
+        }
+    }
+}
+    
+extension CGFloat {
+    public var description: String {
+        if self.truncatingRemainder(dividingBy: 1) == 0.0 {
+            return "\(Int(self))"
+        } else {
+            return "\(self)"
+        }
     }
 }
     

--- a/Sources/Impl/UnitTests.swift
+++ b/Sources/Impl/UnitTests.swift
@@ -19,8 +19,6 @@
 
 import UIKit
 
-public var _pinlayoutUnitTestLastWarning: String?
-
 public func _pinlayoutSetUnitTest(displayScale: CGFloat) {
     Coordinates.displayScale = displayScale
 }

--- a/Sources/ObjectiveC/PinLayoutObjCImpl.swift
+++ b/Sources/ObjectiveC/PinLayoutObjCImpl.swift
@@ -36,6 +36,7 @@ import UIKit
     public func layout() {
         // With objective-c PinLayoutObjCImpl instance are sometimes deallocated only after the context has been quit. For this reason
         // developpers must call the layout: method implicetely.
+        impl?.layout()
         impl = nil
     }
     

--- a/Sources/Pin.swift
+++ b/Sources/Pin.swift
@@ -25,25 +25,26 @@ public enum LayoutDirection {
     case rtl
 }
 
-public class PinLayoutGlobals {
-    public var layoutDirection = LayoutDirection.ltr
+@objc public class Pin: NSObject {
+    public static var layoutDirection = LayoutDirection.ltr
 
 #if DEBUG
-    public var logWarnings = true
+    public static var logWarnings = true
 #else
-    public var logWarnings = false
+    public static var logWarnings = false
 #endif
     
     /**
      If your codes need to work in Xcode playgrounds, you may set to `true` the property
-     `Pin.warnMissingLayoutCalls`, this way any missing call to `layout()` will generate
+     `Pin.logMissingLayoutCalls`, this way any missing call to `layout()` will generate
      a warning in the Xcode console..
     */
-    public var warnMissingLayoutCalls = false
+    public static var logMissingLayoutCalls = false
     
-    public func layoutDirection(_ direction: LayoutDirection) {
+    public static func layoutDirection(_ direction: LayoutDirection) {
         self.layoutDirection = direction
     }
+    
+    // Contains PinLayout last warning's text. Used by PinLayout's Unit Tests.
+    public static var lastWarningText: String?
 }
-
-public let Pin = PinLayoutGlobals()

--- a/Sources/PinLayout.swift
+++ b/Sources/PinLayout.swift
@@ -118,8 +118,6 @@ public extension UIView {
 
 /// PinLayout interface
 public protocol PinLayout {
-    func layout()
-
     //
     // MARK: Layout using distances from superview’s edges
     //
@@ -484,6 +482,18 @@ public protocol PinLayout {
     ///
     /// - Returns: PinLayout
     @discardableResult func pinEdges() -> PinLayout
+    
+    /**
+     The method will execute PinLayout commands immediately. This method is **required only if your
+     source codes should also works in Xcode Playgrounds**. Outside of playgrounds, PinLayout execute
+     this method implicetely, it is not necessary to call it.
+     
+     Examples:
+         ```swift
+         view.pin.top(20).width(100).layout()
+         ```
+    */
+    func layout()
 }
 
 /// Horizontal alignment used with relative positionning methods: above(of relativeView:, aligned:), below(of relativeView:, aligned:)

--- a/Sources/PinLayout.swift
+++ b/Sources/PinLayout.swift
@@ -485,8 +485,8 @@ public protocol PinLayout {
     
     /**
      The method will execute PinLayout commands immediately. This method is **required only if your
-     source codes should also works in Xcode Playgrounds**. Outside of playgrounds, PinLayout execute
-     this method implicetely, it is not necessary to call it.
+     source codes should also work in Xcode Playgrounds**. Outside of playgrounds, PinLayout executes
+     this method implicitly, it is not necessary to call it.
      
      Examples:
          ```swift

--- a/Sources/PinLayoutGlobals.swift
+++ b/Sources/PinLayoutGlobals.swift
@@ -34,6 +34,13 @@ public class PinLayoutGlobals {
     public var logWarnings = false
 #endif
     
+    /**
+     If your codes needs to work in Xcode playgrounds, you may set to `true` the property
+     `Pin.warnMissingLayoutCalls`, this way any missing call to `layout()` will generate
+     a warning in the Xcode console..
+    */
+    public var warnMissingLayoutCalls = false
+    
     public func layoutDirection(_ direction: LayoutDirection) {
         self.layoutDirection = direction
     }

--- a/Sources/PinLayoutGlobals.swift
+++ b/Sources/PinLayoutGlobals.swift
@@ -35,7 +35,7 @@ public class PinLayoutGlobals {
 #endif
     
     /**
-     If your codes needs to work in Xcode playgrounds, you may set to `true` the property
+     If your codes need to work in Xcode playgrounds, you may set to `true` the property
      `Pin.warnMissingLayoutCalls`, this way any missing call to `layout()` will generate
      a warning in the Xcode console..
     */

--- a/Tests/AdjustSizeSpec.swift
+++ b/Tests/AdjustSizeSpec.swift
@@ -49,7 +49,7 @@ class AdjustSizeSpec: QuickSpec {
         }
 
         beforeEach {
-            _pinlayoutUnitTestLastWarning = nil
+            Pin.lastWarningText = nil
             
             viewController = UIViewController()
             
@@ -167,13 +167,13 @@ class AdjustSizeSpec: QuickSpec {
             it("should warn that size()'s width won't be applied") {
                 aView.pin.width(90).size(CGSize(width: 25, height: 25))
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 25.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
+                expect(Pin.lastWarningText).to(contain(["size", "width", "won't be applied", "value has already been set"]))
             }
             
             it("should warn that size()'s height won't be applied") {
                 aView.pin.height(90).size(CGSize(width: 25, height: 25))
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 25.0, height: 90.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["size", "height", "won't be applied", "value has already been set"]))
+                expect(Pin.lastWarningText).to(contain(["size", "height", "won't be applied", "value has already been set"]))
             }
             
             it("should adjust the size of aView by calling a size(...) method") {
@@ -184,19 +184,19 @@ class AdjustSizeSpec: QuickSpec {
             it("should warn that size(of)'s width won't be applied") {
                 aView.pin.width(90).size(of: aViewChild)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 30.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
+                expect(Pin.lastWarningText).to(contain(["size", "width", "won't be applied", "value has already been set"]))
             }
             
             it("should warn that size()'s width won't be applied") {
                 aView.pin.width(90).size(20)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 20.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
+                expect(Pin.lastWarningText).to(contain(["size", "width", "won't be applied", "value has already been set"]))
             }
             
             it("should warn that size()'s width won't be applied") {
                 aView.pin.width(90).size(50%)
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 90.0, height: 200.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["size", "width", "won't be applied", "value has already been set"]))
+                expect(Pin.lastWarningText).to(contain(["size", "width", "won't be applied", "value has already been set"]))
             }
         }
 
@@ -206,7 +206,7 @@ class AdjustSizeSpec: QuickSpec {
         describe("the result of the fitSize() method") {
             it("should not adjust the size of aView if width or height has not been specified") {
                 aView.pin.fitSize()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["fitSize() won't be applied", "neither the width nor the height can be determined"]))                
+                expect(Pin.lastWarningText).to(contain(["fitSize() won't be applied", "neither the width nor the height can be determined"]))
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 100.0, height: 60.0)))
             }
             
@@ -608,29 +608,29 @@ class AdjustSizeSpec: QuickSpec {
         describe("the result of the sizeToFit(.height) && sizeToFit(.width)") {
             it("should warn method") {
                 aView.pin.width(100).fitSize().sizeToFit(.width)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["sizeToFit(.width)", "won't be applied", "conflicts with fitSize()"]))
+                expect(Pin.lastWarningText).to(contain(["sizeToFit(.width)", "won't be applied", "conflicts with fitSize()"]))
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 100.0, height: 16.0)))
             }
         
             it("should warn method") {
                 aView.pin.width(100).fitSize().sizeToFit(.height)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["sizeToFit(.height)", "won't be applied", "conflicts with fitSize()"]))
+                expect(Pin.lastWarningText).to(contain(["sizeToFit(.height)", "won't be applied", "conflicts with fitSize()"]))
                 expect(aView.frame).to(equal(CGRect(x: 140.0, y: 100.0, width: 100.0, height: 16.0)))
             }
         
             it("should warn method") {
                 aView.pin.width(100).aspectRatio(2).sizeToFit(.width)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["sizeToFit(.width)", "won't be applied", "aspectRatio: 2"]))
+                expect(Pin.lastWarningText).to(contain(["sizeToFit(.width)", "won't be applied", "aspectRatio: 2"]))
             }
             
             it("should warn method") {
                 aView.pin.sizeToFit(.width).aspectRatio(2)
-                expect(_pinlayoutUnitTestLastWarning).to(contain([" aspectRatio(2.0)", "won't be applied", "conflicts with sizeToFit(.width)"]))
+                expect(Pin.lastWarningText).to(contain([" aspectRatio(2.0)", "won't be applied", "conflicts with sizeToFit(.width)"]))
             }
             
             it("should warn method") {
                 aView.pin.width(100).fitSize().aspectRatio(2)
-                expect(_pinlayoutUnitTestLastWarning).to(contain([" aspectRatio(2.0)", "won't be applied", "conflicts with fitSize()"]))
+                expect(Pin.lastWarningText).to(contain([" aspectRatio(2.0)", "won't be applied", "conflicts with fitSize()"]))
             }
         }
         

--- a/Tests/AspectRatioTests.swift
+++ b/Tests/AspectRatioTests.swift
@@ -42,7 +42,7 @@ class AspectRatioTests: QuickSpec {
         }
         
         beforeEach {
-            _pinlayoutUnitTestLastWarning = nil
+            Pin.lastWarningText = nil
             
             viewController = UIViewController()
             
@@ -69,54 +69,54 @@ class AspectRatioTests: QuickSpec {
         describe("the result of the aspectRatio(CGFloat)") {
             it("should warn about fitSize()") {
                 aView.pin.left().width(100%).aspectRatio(2).fitSize()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["fitSize() won't be applied", "conflicts", "aspectRatio"]))
+                expect(Pin.lastWarningText).to(contain(["fitSize() won't be applied", "conflicts", "aspectRatio"]))
             }
             
             it("should warn about fitSize()") {
                 aView.pin.left().height(100).aspectRatio(2).fitSize()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["fitSize() won't be applied", "conflicts", "aspectRatio"]))
+                expect(Pin.lastWarningText).to(contain(["fitSize() won't be applied", "conflicts", "aspectRatio"]))
             }
             
             it("should warn about aspectRatio(:CGFloat)") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
                 aView.pin.left().width(100%).fitSize().aspectRatio(2)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["aspectRatio(2.0) won't be applied", "conflicts", "fitSize()"]))
+                expect(Pin.lastWarningText).to(contain(["aspectRatio(2.0) won't be applied", "conflicts", "fitSize()"]))
             }
 
             it("should warn about aspectRatio(:CGFloat)") {
                 aView.sizeThatFitsExpectedArea = 40 * 40
                 aView.pin.left().height(100).fitSize().aspectRatio(2)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["aspectRatio(2.0) won't be applied", "conflicts", "fitSize"]))
+                expect(Pin.lastWarningText).to(contain(["aspectRatio(2.0) won't be applied", "conflicts", "fitSize"]))
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 16.0, height: 100.0)))
             }
             
             it("should warn about aspectRatio(:CGFloat)") {
                 aView.pin.left().aspectRatio(2)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["aspectRatio won't be applied", "neither the width nor the height can be determined"]))
+                expect(Pin.lastWarningText).to(contain(["aspectRatio won't be applied", "neither the width nor the height can be determined"]))
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 200.0, height: 100.0)))
             }
             
             it("should warn about aspectRatio(:CGFloat)") {
                 aView.pin.left().width(100%).aspectRatio(-2)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["aspectRatio", "won't be applied", "must be greater than zero"]))
+                expect(Pin.lastWarningText).to(contain(["aspectRatio", "won't be applied", "must be greater than zero"]))
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 400.0, height: 100.0)))
             }
             
             it("should warn about aspectRatio(:CGFloat)") {
                 aView.pin.left().height(100).aspectRatio(-2)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["aspectRatio", "won't be applied", "must be greater than zero"]))
+                expect(Pin.lastWarningText).to(contain(["aspectRatio", "won't be applied", "must be greater than zero"]))
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 200.0, height: 100.0)))
             }
             
             it("should warn about aspectRatio(:CGFloat)") {
                 aView.pin.left().width(100%).aspectRatio(0)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["aspectRatio", "won't be applied", "must be greater than zero"]))
+                expect(Pin.lastWarningText).to(contain(["aspectRatio", "won't be applied", "must be greater than zero"]))
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 400.0, height: 100.0)))
             }
             
             it("should warn about aspectRatio(:CGFloat)") {
                 aView.pin.left().height(100).aspectRatio(0)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["aspectRatio", "won't be applied", "must be greater than zero"]))
+                expect(Pin.lastWarningText).to(contain(["aspectRatio", "won't be applied", "must be greater than zero"]))
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 200.0, height: 100.0)))
             }
 
@@ -165,13 +165,13 @@ class AspectRatioTests: QuickSpec {
         describe("the result of the aspectRatio(CGFloat)") {
             it("should warn about aspectRatio()") {
                 aView.pin.left().width(100).aspectRatio()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["aspectRatio() won't be applied", "the layouted must be an UIImageView()"]))
+                expect(Pin.lastWarningText).to(contain(["aspectRatio() won't be applied", "the layouted must be an UIImageView()"]))
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 100.0, height: 100.0)))
             }
             
             it("should warn about aspectRatio()") {
                 imageView.pin.left().aspectRatio()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["aspectRatio won't be applied", "neither the width nor the height can be determined"]))
+                expect(Pin.lastWarningText).to(contain(["aspectRatio won't be applied", "neither the width nor the height can be determined"]))
                 expect(imageView.frame).to(equal(CGRect(x: 0.0, y: 10.0, width: 60.0, height: 60.0)))
             }
             

--- a/Tests/JustifyAlignSpec.swift
+++ b/Tests/JustifyAlignSpec.swift
@@ -38,7 +38,7 @@ class JustifyAlignSpec: QuickSpec {
         }
 
         beforeEach {
-            _pinlayoutUnitTestLastWarning = nil
+            Pin.lastWarningText = nil
             
             viewController = UIViewController()
             
@@ -59,31 +59,31 @@ class JustifyAlignSpec: QuickSpec {
             it("test when missing left and right coordinate") {
                 aView.pin.justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
+                expect(Pin.lastWarningText).to(contain(["justify", "center", "won't be applied", "left and right"]))
             }
             
             it("test when missing left and right coordinate") {
                 aView.pin.width(100).justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
+                expect(Pin.lastWarningText).to(contain(["justify", "center", "won't be applied", "left and right"]))
             }
             
             it("test when missing left and right coordinate") {
                 aView.pin.left().pinEdges().justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
+                expect(Pin.lastWarningText).to(contain(["justify", "center", "won't be applied", "left and right"]))
             }
             
             it("test when missing right coordinate") {
                 aView.pin.left().width(250).justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify", "center", "won't be applied", "left and right"]))
+                expect(Pin.lastWarningText).to(contain(["justify", "center", "won't be applied", "left and right"]))
             }
             
             it("test when hCenter has been set and justify() won't be applied") {
                 aView.pin.hCenter(60).justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 210.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify", "center", "won't be applied", "hCenter"]))
+                expect(Pin.lastWarningText).to(contain(["justify", "center", "won't be applied", "hCenter"]))
             }
         }
         
@@ -94,31 +94,31 @@ class JustifyAlignSpec: QuickSpec {
             it("test when missing top and bottom coordinate") {
                 aView.pin.align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
+                expect(Pin.lastWarningText).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
             }
             
             it("test when missing left and right coordinate") {
                 aView.pin.width(100).align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
+                expect(Pin.lastWarningText).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
             }
             
             it("test when missing left and right coordinate") {
                 aView.pin.left().pinEdges().align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
+                expect(Pin.lastWarningText).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
             }
             
             it("test when missing right coordinate") {
                 aView.pin.left().width(250).align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
+                expect(Pin.lastWarningText).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
             }
             
             it("test when hCenter has been set and align() won't be applied") {
                 aView.pin.hCenter(60).align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 210.0, y: 100.0, width: 100.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
+                expect(Pin.lastWarningText).to(contain(["align(.center)", "won't be applied", "top and bottom"]))
             }
         }
         

--- a/Tests/LayoutMethodSpec.swift
+++ b/Tests/LayoutMethodSpec.swift
@@ -38,7 +38,7 @@ class LayoutMethodSpec: QuickSpec {
         }
 
         beforeEach {
-            _pinlayoutUnitTestLastWarning = nil
+            Pin.lastWarningText = nil
             Pin.warnMissingLayoutCalls = false
             
             viewController = UIViewController()
@@ -64,7 +64,7 @@ class LayoutMethodSpec: QuickSpec {
                 let aViewFrame = aView.frame
                 aView.pin.left().right()
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 400.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(beNil())
+                expect(Pin.lastWarningText).to(beNil())
                 
                 aView.frame = aViewFrame
                 aView.pin.left().right().layout()
@@ -75,7 +75,7 @@ class LayoutMethodSpec: QuickSpec {
                 Pin.warnMissingLayoutCalls = true
                 
                 aView.pin.left().right()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["PinLayout commands have been issued without calling the 'layout()' method"]))
+                expect(Pin.lastWarningText).to(contain(["PinLayout commands have been issued without calling the 'layout()' method"]))
             }
         }
     }

--- a/Tests/LayoutMethodSpec.swift
+++ b/Tests/LayoutMethodSpec.swift
@@ -39,7 +39,7 @@ class LayoutMethodSpec: QuickSpec {
 
         beforeEach {
             Pin.lastWarningText = nil
-            Pin.warnMissingLayoutCalls = false
+            Pin.logMissingLayoutCalls = false
             
             viewController = UIViewController()
             
@@ -53,7 +53,7 @@ class LayoutMethodSpec: QuickSpec {
         }
         
         afterEach {
-            Pin.warnMissingLayoutCalls = false
+            Pin.logMissingLayoutCalls = false
         }
         
         //
@@ -71,8 +71,8 @@ class LayoutMethodSpec: QuickSpec {
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 400.0, height: 60.0)))
             }
             
-            it("should warn if layout() is not called when Pin.warnMissingLayoutCalls is set to true") {
-                Pin.warnMissingLayoutCalls = true
+            it("should warn if layout() is not called when Pin.logMissingLayoutCalls is set to true") {
+                Pin.logMissingLayoutCalls = true
                 
                 aView.pin.left().right()
                 expect(Pin.lastWarningText).to(contain(["PinLayout commands have been issued without calling the 'layout()' method"]))

--- a/Tests/LayoutMethodSpec.swift
+++ b/Tests/LayoutMethodSpec.swift
@@ -1,0 +1,82 @@
+//  Copyright (c) 2017 Luc Dion
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Quick
+import Nimble
+import PinLayout
+
+class LayoutMethodSpec: QuickSpec {
+    override func spec() {
+        var viewController: UIViewController!
+        var rootView: BasicView!
+        var aView: BasicView!
+        
+        /*
+          root
+           |
+            - aView
+        */
+        
+        beforeSuite {
+            _pinlayoutSetUnitTest(displayScale: 2)
+        }
+
+        beforeEach {
+            _pinlayoutUnitTestLastWarning = nil
+            Pin.warnMissingLayoutCalls = false
+            
+            viewController = UIViewController()
+            
+            rootView = BasicView(text: "", color: .white)
+            rootView.frame = CGRect(x: 0, y: 0, width: 400, height: 400)
+            viewController.view.addSubview(rootView)
+            
+            aView = BasicView(text: "View A", color: UIColor.red.withAlphaComponent(0.5))
+            aView.frame = CGRect(x: 40, y: 100, width: 100, height: 60)
+            rootView.addSubview(aView)
+        }
+        
+        afterEach {
+            Pin.warnMissingLayoutCalls = false
+        }
+        
+        //
+        // layout()
+        //
+        describe("layout()") {
+            it("test layout() method") {
+                let aViewFrame = aView.frame
+                aView.pin.left().right()
+                expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 400.0, height: 60.0)))
+                expect(_pinlayoutUnitTestLastWarning).to(beNil())
+                
+                aView.frame = aViewFrame
+                aView.pin.left().right().layout()
+                expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 400.0, height: 60.0)))
+            }
+            
+            it("should warn if layout() is not called when Pin.warnMissingLayoutCalls is set to true") {
+                Pin.warnMissingLayoutCalls = true
+                
+                aView.pin.left().right()
+                expect(_pinlayoutUnitTestLastWarning).to(contain(["PinLayout commands have been issued without calling the 'layout()' method"]))
+            }
+        }
+    }
+}

--- a/Tests/MinMaxWidthHeightSpec.swift
+++ b/Tests/MinMaxWidthHeightSpec.swift
@@ -38,7 +38,7 @@ class MinMaxWidthHeightSpec: QuickSpec {
         }
 
         beforeEach {
-            _pinlayoutUnitTestLastWarning = nil
+            Pin.lastWarningText = nil
             
             viewController = UIViewController()
             
@@ -122,7 +122,7 @@ class MinMaxWidthHeightSpec: QuickSpec {
             it("should adjust the width when using hCenter") {
                 aView.pin.hCenter().width(20).minWidth(250).justify(.left)
                 expect(aView.frame).to(equal(CGRect(x: 75.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify(.left)", "won't be applied", "justification is not applied when hCenter has been set"]))
+                expect(Pin.lastWarningText).to(contain(["justify(.left)", "won't be applied", "justification is not applied when hCenter has been set"]))
             }
         }
         
@@ -203,25 +203,25 @@ class MinMaxWidthHeightSpec: QuickSpec {
             it("should adjust the width using justify") {
                 aView.pin.left().width(100%).maxWidth(250).justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify(.center)", "won't be applied", "left and right coordinates"]))
+                expect(Pin.lastWarningText).to(contain(["justify(.center)", "won't be applied", "left and right coordinates"]))
             }
             
             it("should adjust the width using justify") {
                 aView.pin.left().width(100%).maxWidth(250).justify(.right)
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify(.right)", "won't be applied", "left and right coordinates"]))
+                expect(Pin.lastWarningText).to(contain(["justify(.right)", "won't be applied", "left and right coordinates"]))
             }
             
             it("should adjust the width using justify") {
                 aView.pin.right().width(100%).maxWidth(250).justify(.left)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify(.left)", "won't be applied", "left and right coordinates"]))
+                expect(Pin.lastWarningText).to(contain(["justify(.left)", "won't be applied", "left and right coordinates"]))
             }
             
             it("should adjust the width using justify") {
                 aView.pin.right().width(100%).maxWidth(250).justify(.center)
                 expect(aView.frame).to(equal(CGRect(x: 150.0, y: 100.0, width: 250.0, height: 60.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["justify(.center)", "won't be applied", "left and right coordinates"]))
+                expect(Pin.lastWarningText).to(contain(["justify(.center)", "won't be applied", "left and right coordinates"]))
             }
             
             it("should adjust the width using justify") {
@@ -414,7 +414,7 @@ class MinMaxWidthHeightSpec: QuickSpec {
             it("should adjust the height when using hCenter") {
                 aView.pin.vCenter().height(20).minHeight(250).align(.top)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 75.0, width: 100.0, height: 250.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.top)", "won't be applied", "alignment is not applied when vCenter has been set"]))
+                expect(Pin.lastWarningText).to(contain(["align(.top)", "won't be applied", "alignment is not applied when vCenter has been set"]))
             }
         }
         
@@ -490,37 +490,37 @@ class MinMaxWidthHeightSpec: QuickSpec {
             it("should adjust the height using align") {
                 aView.pin.top().height(100%).maxHeight(250).align(.top)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 00.0, width: 100.0, height: 250.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.top)", "won't be applied", "top and bottom coordinates"]))
+                expect(Pin.lastWarningText).to(contain(["align(.top)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {
                 aView.pin.top().height(100%).maxHeight(250).align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 0.0, width: 100.0, height: 250.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom coordinates"]))
+                expect(Pin.lastWarningText).to(contain(["align(.center)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {
                 aView.pin.top().height(100%).maxHeight(250).align(.bottom)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 00.0, width: 100.0, height: 250.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.bottom)", "won't be applied", "top and bottom coordinates"]))
+                expect(Pin.lastWarningText).to(contain(["align(.bottom)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {
                 aView.pin.bottom().height(100%).maxHeight(250).align(.top)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 150.0, width: 100.0, height: 250.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.top)", "won't be applied", "top and bottom coordinates"]))
+                expect(Pin.lastWarningText).to(contain(["align(.top)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {
                 aView.pin.bottom().height(100%).maxHeight(250).align(.center)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 150.0, width: 100.0, height: 250.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.center)", "won't be applied", "top and bottom coordinates"]))
+                expect(Pin.lastWarningText).to(contain(["align(.center)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {
                 aView.pin.bottom().height(100%).maxHeight(250).align(.bottom)
                 expect(aView.frame).to(equal(CGRect(x: 40.0, y: 150.0, width: 100.0, height: 250.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["align(.bottom)", "won't be applied", "top and bottom coordinates"]))
+                expect(Pin.lastWarningText).to(contain(["align(.bottom)", "won't be applied", "top and bottom coordinates"]))
             }
 
             it("should adjust the height using align") {

--- a/Tests/ObjectiveCSpec.m
+++ b/Tests/ObjectiveCSpec.m
@@ -1,0 +1,63 @@
+//
+//  ObjectiveCSpec.m
+//  PinLayout
+//
+//  Created by DION, Luc (MTL) on 2017-11-21.
+//  Copyright © 2017 mcswiftlayyout.mirego.com. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@import Quick;
+@import Nimble;
+@import XCTest;
+@import UIKit;
+@import PinLayout;
+
+QuickSpecBegin(ObjectiveCSpec)
+
+describe(@"test Objective-C interface", ^{
+    __block UIViewController* viewController = nil;
+    __block UIView* rootView = nil;
+    __block UIView* aView = nil;
+    
+    beforeEach(^{
+        Pin.warnMissingLayoutCalls = false;
+        Pin.lastWarningText = nil;
+        
+        viewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
+        
+        rootView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)];
+        [viewController.view addSubview:rootView];
+        
+        aView = [[UIView alloc] initWithFrame:CGRectMake(40, 100, 100, 60)];
+        [rootView addSubview:aView];
+    });
+    
+    afterEach(^{
+        Pin.warnMissingLayoutCalls = false;
+    });
+    
+    describe(@"its click", ^{
+        it(@"is loud", ^{
+            [[[aView pinObjc] top:10] layout];
+            expect(@(aView.frame)).to(equal(@(CGRectMake(40, 10, 100, 60))));
+        });
+        
+        it(@"using Pin.warnMissingLayoutCalls", ^{
+            Pin.warnMissingLayoutCalls = true;
+            [[aView pinObjc] top:10];
+            expect(@(aView.frame)).to(equal(@(CGRectMake(40, 10, 100, 60))));
+            expect(Pin.lastWarningText).to(contain(@"PinLayout commands have been issued without calling the 'layout()' method to complete the layout"));
+        });
+
+        it(@"using Pin.warnMissingLayoutCalls set to false", ^{
+            Pin.warnMissingLayoutCalls = false;
+            [[[aView pinObjc] top:10] layout];
+            expect(@(aView.frame)).to(equal(@(CGRectMake(40, 10, 100, 60))));
+            expect(Pin.lastWarningText).to(beNil());
+        });
+    });
+});
+
+QuickSpecEnd

--- a/Tests/ObjectiveCSpec.m
+++ b/Tests/ObjectiveCSpec.m
@@ -22,7 +22,7 @@ describe(@"test Objective-C interface", ^{
     __block UIView* aView = nil;
     
     beforeEach(^{
-        Pin.warnMissingLayoutCalls = false;
+        Pin.logMissingLayoutCalls = false;
         Pin.lastWarningText = nil;
         
         viewController = [[UIViewController alloc] initWithNibName:nil bundle:nil];
@@ -35,7 +35,7 @@ describe(@"test Objective-C interface", ^{
     });
     
     afterEach(^{
-        Pin.warnMissingLayoutCalls = false;
+        Pin.logMissingLayoutCalls = false;
     });
     
     describe(@"its click", ^{
@@ -44,15 +44,15 @@ describe(@"test Objective-C interface", ^{
             expect(@(aView.frame)).to(equal(@(CGRectMake(40, 10, 100, 60))));
         });
         
-        it(@"using Pin.warnMissingLayoutCalls", ^{
-            Pin.warnMissingLayoutCalls = true;
+        it(@"using Pin.logMissingLayoutCalls", ^{
+            Pin.logMissingLayoutCalls = true;
             [[aView pinObjc] top:10];
             expect(@(aView.frame)).to(equal(@(CGRectMake(40, 10, 100, 60))));
             expect(Pin.lastWarningText).to(contain(@"PinLayout commands have been issued without calling the 'layout()' method to complete the layout"));
         });
 
-        it(@"using Pin.warnMissingLayoutCalls set to false", ^{
-            Pin.warnMissingLayoutCalls = false;
+        it(@"using Pin.logMissingLayoutCalls set to false", ^{
+            Pin.logMissingLayoutCalls = false;
             [[[aView pinObjc] top:10] layout];
             expect(@(aView.frame)).to(equal(@(CGRectMake(40, 10, 100, 60))));
             expect(Pin.lastWarningText).to(beNil());

--- a/Tests/PinEdgesSpec.swift
+++ b/Tests/PinEdgesSpec.swift
@@ -39,7 +39,7 @@ class PinEdgesSpec: QuickSpec {
         */
 
         beforeEach {
-            _pinlayoutUnitTestLastWarning = nil
+            Pin.lastWarningText = nil
         
             viewController = UIViewController()
             
@@ -339,7 +339,7 @@ class PinEdgesSpec: QuickSpec {
             it("should not apply hCenter") {
                 aView.pin.left().hCenter(-20)
                 expect(aView.frame).to(equal(CGRect(x: 0, y: 100.0, width: 200.0, height: 100.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["hCenter", "won't be applied", "left"]))
+                expect(Pin.lastWarningText).to(contain(["hCenter", "won't be applied", "left"]))
             }
             
             // hCenter(%)
@@ -407,7 +407,7 @@ class PinEdgesSpec: QuickSpec {
             it("should adjust the aView") {
                 aView.pin.top().vCenter(-20)
                 expect(aView.frame).to(equal(CGRect(x: 140, y: 0.0, width: 200.0, height: 100.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["vCenter", "won't be applied", "top"]))
+                expect(Pin.lastWarningText).to(contain(["vCenter", "won't be applied", "top"]))
             }
             
             it("should warns that the view is not added to any view") {
@@ -415,7 +415,7 @@ class PinEdgesSpec: QuickSpec {
                 unAttachedView.pin.vCenter(20%)
                 
                 expect(unAttachedView.frame).to(equal(CGRect(x: 10, y: 10, width: 200.0, height: 10)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["vCenter", "won't be applied", "view must be added"]))
+                expect(Pin.lastWarningText).to(contain(["vCenter", "won't be applied", "view must be added"]))
             }
             
             it("should adjust the aView") {
@@ -431,7 +431,7 @@ class PinEdgesSpec: QuickSpec {
             it("should adjust the aView") {
                 aView.pin.top().vCenter(-20%)
                 expect(aView.frame).to(equal(CGRect(x: 140, y: 0.0, width: 200.0, height: 100.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["vCenter", "won't be applied", "top"]))
+                expect(Pin.lastWarningText).to(contain(["vCenter", "won't be applied", "top"]))
             }
             
             // vCenter(to: ...)
@@ -482,20 +482,20 @@ class PinEdgesSpec: QuickSpec {
             
             it("should warn") {
                 aView.pin.top(20).all()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["all() top coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["all() top coordinate", "won't be applied", "already been set to 20.0"]))
             }
             it("should warn") {
                 aView.pin.left(20).all()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["all() left coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["all() left coordinate", "won't be applied", "already been set to 20.0"]))
             }
             it("should warn") {
                 aView.pin.right(20).all()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["all() right coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["all() right coordinate", "won't be applied", "already been set to 20.0"]))
             }
             
             it("should warn") {
                 aView.pin.bottom(20).all()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["all() bottom coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["all() bottom coordinate", "won't be applied", "already been set to 20.0"]))
             }
         }
         
@@ -525,11 +525,11 @@ class PinEdgesSpec: QuickSpec {
             
             it("should warn") {
                 aView.pin.left(20).horizontally()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["horizontally() left coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["horizontally() left coordinate", "won't be applied", "already been set to 20.0"]))
             }
             it("should warn") {
                 aView.pin.right(20).horizontally()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["horizontally() right coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["horizontally() right coordinate", "won't be applied", "already been set to 20.0"]))
             }
         }
         
@@ -559,11 +559,11 @@ class PinEdgesSpec: QuickSpec {
 
             it("should warn") {
                 aView.pin.top(20).vertically()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["vertically() top coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["vertically() top coordinate", "won't be applied", "already been set to 20.0"]))
             }
             it("should warn") {
                 aView.pin.bottom(20).vertically()
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["vertically() bottom coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["vertically() bottom coordinate", "won't be applied", "already been set to 20.0"]))
             }
         }
     }

--- a/Tests/PinEdgesSpec.swift
+++ b/Tests/PinEdgesSpec.swift
@@ -482,20 +482,20 @@ class PinEdgesSpec: QuickSpec {
             
             it("should warn") {
                 aView.pin.top(20).all()
-                expect(Pin.lastWarningText).to(contain(["all() top coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["all() top coordinate", "won't be applied", "already been set to 20"]))
             }
             it("should warn") {
                 aView.pin.left(20).all()
-                expect(Pin.lastWarningText).to(contain(["all() left coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["all() left coordinate", "won't be applied", "already been set to 20"]))
             }
             it("should warn") {
                 aView.pin.right(20).all()
-                expect(Pin.lastWarningText).to(contain(["all() right coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["all() right coordinate", "won't be applied", "already been set to 20"]))
             }
             
             it("should warn") {
                 aView.pin.bottom(20).all()
-                expect(Pin.lastWarningText).to(contain(["all() bottom coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["all() bottom coordinate", "won't be applied", "already been set to 20"]))
             }
         }
         
@@ -525,11 +525,11 @@ class PinEdgesSpec: QuickSpec {
             
             it("should warn") {
                 aView.pin.left(20).horizontally()
-                expect(Pin.lastWarningText).to(contain(["horizontally() left coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["horizontally() left coordinate", "won't be applied", "already been set to 20"]))
             }
             it("should warn") {
                 aView.pin.right(20).horizontally()
-                expect(Pin.lastWarningText).to(contain(["horizontally() right coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["horizontally() right coordinate", "won't be applied", "already been set to 20"]))
             }
         }
         
@@ -559,11 +559,11 @@ class PinEdgesSpec: QuickSpec {
 
             it("should warn") {
                 aView.pin.top(20).vertically()
-                expect(Pin.lastWarningText).to(contain(["vertically() top coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["vertically() top coordinate", "won't be applied", "already been set to 20"]))
             }
             it("should warn") {
                 aView.pin.bottom(20).vertically()
-                expect(Pin.lastWarningText).to(contain(["vertically() bottom coordinate", "won't be applied", "already been set to 20.0"]))
+                expect(Pin.lastWarningText).to(contain(["vertically() bottom coordinate", "won't be applied", "already been set to 20"]))
             }
         }
     }

--- a/Tests/RTLSpec.swift
+++ b/Tests/RTLSpec.swift
@@ -38,7 +38,7 @@ class RTLSpec: QuickSpec {
         */
 
         beforeEach {
-            _pinlayoutUnitTestLastWarning = nil
+            Pin.lastWarningText = nil
             Pin.layoutDirection(.ltr)
             
             viewController = UIViewController()
@@ -62,50 +62,50 @@ class RTLSpec: QuickSpec {
         describe("warn") {
             it("should display a warning") {
                 aView.pin.start(10).left(20)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["left", "won't be applied", "already been set to 10"]))
             }
             
             it("should display a warning") {
                 aView.pin.end(10).right(20)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["right", "won't be applied", "already been set to 10"]))
             }
 
             it("should display a warning") {
                 Pin.layoutDirection(.auto)
                 aView.pin.start(10).left(20)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["left", "won't be applied", "already been set to 10"]))
             }
             
             it("should display a warning") {
                 Pin.layoutDirection(.auto)
                 aView.pin.end(10).right(20)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["right", "won't be applied", "already been set to 10"]))
             }
             
             it("should display a warning") {
                 Pin.layoutDirection(.ltr)
                 aView.pin.start(10).left(20)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["left", "won't be applied", "already been set to 10"]))
             }
             
             it("should display a warning") {
                 Pin.layoutDirection(.ltr)
                 aView.pin.end(10).right(20)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["right", "won't be applied", "already been set to 10"]))
             }
 
             it("should display a warning") {
                 // With RTL
                 Pin.layoutDirection(.rtl)
                 aView.pin.start(10).right(20)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["right", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["right", "won't be applied", "already been set to 10"]))
             }
             
             it("should display a warning") {
                 // With RTL
                 Pin.layoutDirection(.rtl)
                 aView.pin.end(10).left(20)
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["left", "won't be applied", "already been set to 10"]))
+                expect(Pin.lastWarningText).to(contain(["left", "won't be applied", "already been set to 10"]))
             }
         }
         

--- a/Tests/RelativePositionMultipleViewsSpec.swift
+++ b/Tests/RelativePositionMultipleViewsSpec.swift
@@ -46,7 +46,7 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
         */
 
         beforeEach {
-            _pinlayoutUnitTestLastWarning = nil
+            Pin.lastWarningText = nil
             
             viewController = UIViewController()
             
@@ -79,21 +79,21 @@ class RelativePositionMultipleViewsSpec: QuickSpec {
                 let unatachedView = UIView()
                 bViewChild.pin.above(of: unatachedView)
                 expect(bViewChild.frame).to(equal(CGRect(x: 40, y: 10, width: 60, height: 20)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["above", "won't be applied", "no valid references"]))
+                expect(Pin.lastWarningText).to(contain(["above", "won't be applied", "no valid references"]))
             }
             
             it("should warns the view bottom edge") {
                 let unatachedView = UIView()
                 bViewChild.pin.above(of: [aView, unatachedView])
                 expect(bViewChild.frame).to(equal(CGRect(x: 40.0, y: -40.0, width: 60.0, height: 20.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["above", "won't be applied", "the reference view", "must be added", "as a reference"]))
+                expect(Pin.lastWarningText).to(contain(["above", "won't be applied", "the reference view", "must be added", "as a reference"]))
             }
             
             it("Should warn, but the view should be anyway layout it above") {
                 let unatachedView = UIView()
                 bViewChild.pin.above(of: [aView, unatachedView])
                 expect(bViewChild.frame).to(equal(CGRect(x: 40.0, y: -40.0, width: 60.0, height: 20.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["above", "won't be applied", "the reference view", "must be added", "as a reference"]))
+                expect(Pin.lastWarningText).to(contain(["above", "won't be applied", "the reference view", "must be added", "as a reference"]))
             }
         }
         

--- a/Tests/WarningSpec.swift
+++ b/Tests/WarningSpec.swift
@@ -38,7 +38,7 @@ class WarningSpec: QuickSpec {
         }
 
         beforeEach {
-            _pinlayoutUnitTestLastWarning = nil
+            Pin.lastWarningText = nil
             
             viewController = UIViewController()
             
@@ -59,7 +59,7 @@ class WarningSpec: QuickSpec {
             it("test when top, left, bottom and right is set") {
                 aView.pin.top().bottom().left().right().width(100%).pinEdges()
                 expect(aView.frame).to(equal(CGRect(x: 0.0, y: 0.0, width: 400.0, height: 400.0)))
-                expect(_pinlayoutUnitTestLastWarning).to(contain(["pinEdges()", "won't be applied", "top, left, bottom and right coordinates are already set"]))
+                expect(Pin.lastWarningText).to(contain(["pinEdges()", "won't be applied", "top, left, bottom and right coordinates are already set"]))
             }
         }
     }

--- a/docs/objective_c.md
+++ b/docs/objective_c.md
@@ -2,9 +2,9 @@
 	<img src="pinlayout-logo-small.png" width=100/>
 </p>
 
-<h1 align="center" style="color: #376C9D; font-family: Arial Black, Gadget, sans-serif; font-size: 1.5em">PinLayout Objective-C</h1>
+<h1 align="center" style="color: #376C9D; font-family: Arial Black, Gadget, sans-serif; font-size: 1.5em">PinLayout using Objective-C</h1>
 
-PinLayout can also be used from Objective-C. The PinLayout interface is slightly different from the Swift interface due to more limited objective-c parameter definitions.
+PinLayout can also be used from Objective-C. The PinLayout interface is slightly different from the Swift interface due to more limited Objective-C parameters definitions.
 
 ###### Example 1:
 This example implement the PinLayout's Intro example using objective-c 
@@ -34,9 +34,13 @@ The PinLayout's objective-c interface is available using the property `pinObjc` 
  [[view.pinObjc top] layout];
 ``` 
 
-#### `layout` method
+#### `layout()`
 
-When using the Objective-c interface, the `layout` method must be called explicitly to complete the view's layout. 
+**Method:**
+
+* **`layout()`**  
+When using the Objective-c interface, the `layout` method must be called explicitly to complete the view's layout. The method will execute PinLayout commands immediately. In Swift, PinLayout executes this method implicitly, it is not necessary to call it. 
+
 
 ```
  // Swift

--- a/docs/xcode_playground.md
+++ b/docs/xcode_playground.md
@@ -1,0 +1,22 @@
+<p align="center">
+	<img src="pinlayout-logo-small.png" width=100/>
+</p>
+
+<h1 align="center" style="color: #376C9D; font-family: Arial Black, Gadget, sans-serif; font-size: 1.5em">PinLayout and Xcode Playgrounds</h1>
+
+## Using PinLayout with Xcode Playgrounds <a name="playgrounds"></a>
+PinLayout layouts views immediately after the line containing `.pin` has been fully executed, thanks to ARC (Automatic Reference Counting) this works perfectly on iOS/tvOS/macOS simulators and devices. But in Xcode Playgrounds, ARC doesn't work as expected, object references are kept much longer. This is a well documented issue. The impact of this problem is that PinLayout doesn't layout views at the time and in the order required. To handle this situation in playgrounds it is possible to call the `layout()` method to complete the layout.
+
+**Method:**
+
+* **`layout()`**  
+The method will execute PinLayout commands immediately. This method is **required only if your source codes should also work in Xcode Playgrounds**. Outside of playgrounds, PinLayout executes this method implicitly, it is not necessary to call it. 
+
+###### Usage Examples:
+
+```swift
+    view.pin.top(20).bottom(20).width(100).layout()
+    view2.pin.below(of: view).left().right().layout()
+```
+
+**TIP**: If your codes needs to work in Xcode playgrounds, you may set to `true` the property `Pin.logMissingLayoutCalls`, this way any missing call to `layout()` will generate a warning in the Xcode console.


### PR DESCRIPTION
Changes:
##### Add `layout()` method
PinLayout layouts views immediately after the line containing `.pin` has been fully executed, thanks to ARC (Automatic Reference Counting) this works perfectly on iOS/tvOS/macOS simulators and devices. But in Xcode Playgrounds, ARC doesn't work as expected, object references are kept much longer. This is a well-documented issue. The impact of this problem is that PinLayout doesn't layout views at the time and in the order required. To handle this situation in playgrounds it is possible to call the `layout()` method to complete the layout.

* **`layout()`**  
The method will execute PinLayout commands immediately. This method is **required only if your source codes should also work in Xcode Playgrounds**. Outside of playgrounds, PinLayout executes this method implicitly, it is not necessary to call it. 

###### Usage Examples:

```swift
    view.pin.top(20).bottom(20).width(100).layout()
    view2.pin.below(of: view).left().right().layout()
```

**TIP**: If your codes need to work in Xcode playgrounds, you may set to `true` the property `Pin.warnMissingLayoutCalls`, this way any missing call to `layout()` will generate a warning in the Xcode console.