### PR TITLE
Previously PinLayout was setting the view's frame. This was breaking the view's tranform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: objective-c
-osx_image: xcode9
+osx_image: xcode9.2 
 
 env:
   matrix:
-    - SCHEME=PinLayout       SDK=iphonesimulator11.0
+    - SCHEME=PinLayout       SDK=iphonesimulator11.2
     #- SCHEME=PinLayout       SDK=iphonesimulator10.3
-    #- SCHEME=PinLayoutSample SDK=iphonesimulator11.0
+    #- SCHEME=PinLayoutSample SDK=iphonesimulator11.2
     #- SCHEME=PinLayoutTVOS   SDK=appletvsimulator11.0 
 
 before_install:

--- a/Example/PinLayoutSample.xcodeproj/xcshareddata/xcschemes/PinLayoutSample.xcscheme
+++ b/Example/PinLayoutSample.xcodeproj/xcshareddata/xcschemes/PinLayoutSample.xcscheme
@@ -29,6 +29,16 @@
       language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "249EFE821E64FB4C00165E39"
+               BuildableName = "PinLayoutTests.xctest"
+               BlueprintName = "PinLayoutTests"
+               ReferencedContainer = "container:../PinLayout.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/PinLayout.podspec
+++ b/PinLayout.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "PinLayout"
-  s.version      = "1.5.1"
+  s.version      = "1.5.2"
   s.summary      = "Fast Swift UIViews layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable."
   s.description  = "Fast Swift UIViews layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable."
 

--- a/PinLayout.xcodeproj/project.pbxproj
+++ b/PinLayout.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		243C620C1FC37FA30082C327 /* PinLayoutTVOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 2475B6D71FC37D4D0054CADD /* PinLayoutTVOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		243C620F1FC3834B0082C327 /* Percent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243C620E1FC3834B0082C327 /* Percent.swift */; };
 		244C6E151E776A0C0074FC74 /* MarginsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244C6E141E776A0C0074FC74 /* MarginsSpec.swift */; };
+		245C1DA31FEC4FCC007594F7 /* TransformSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 245C1DA11FEC4FC6007594F7 /* TransformSpec.swift */; };
 		2469C4FC1E74855D00073BEE /* PinEdgeCoordinateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2469C4FB1E74855D00073BEE /* PinEdgeCoordinateSpec.swift */; };
 		2469C5001E75D74000073BEE /* AdjustSizeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2469C4FF1E75D74000073BEE /* AdjustSizeSpec.swift */; };
 		2469C5021E75D88500073BEE /* BasicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2469C5011E75D88500073BEE /* BasicView.swift */; };
@@ -93,6 +94,7 @@
 		243C620E1FC3834B0082C327 /* Percent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Percent.swift; path = Impl/Percent.swift; sourceTree = "<group>"; };
 		244C6E141E776A0C0074FC74 /* MarginsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarginsSpec.swift; sourceTree = "<group>"; };
 		244DF2F81EF46C500090508B /* PinLayoutTVOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PinLayoutTVOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		245C1DA11FEC4FC6007594F7 /* TransformSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransformSpec.swift; sourceTree = "<group>"; };
 		2469C4FB1E74855D00073BEE /* PinEdgeCoordinateSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinEdgeCoordinateSpec.swift; sourceTree = "<group>"; };
 		2469C4FF1E75D74000073BEE /* AdjustSizeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdjustSizeSpec.swift; sourceTree = "<group>"; };
 		2469C5011E75D88500073BEE /* BasicView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicView.swift; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 				240F88BC1F0C042500280FC8 /* JustifyAlignSpec.swift */,
 				243B12C41FC3CFC10072A9C3 /* LayoutMethodSpec.swift */,
 				244C6E141E776A0C0074FC74 /* MarginsSpec.swift */,
+				245C1DA11FEC4FC6007594F7 /* TransformSpec.swift */,
 				242723711F008B85006A5C3A /* MinMaxWidthHeightSpec.swift */,
 				243B12C91FC469550072A9C3 /* ObjectiveCSpec.m */,
 				249EFE881E64FB4C00165E39 /* PinLayoutTests.swift */,
@@ -521,6 +524,7 @@
 				243B12CB1FC469D00072A9C3 /* ObjectiveCSpec.m in Sources */,
 				248E4C741F7A883800C0E7F7 /* AspectRatioTests.swift in Sources */,
 				240F88C11F0C1F5000280FC8 /* WarningSpec.swift in Sources */,
+				245C1DA31FEC4FCC007594F7 /* TransformSpec.swift in Sources */,
 				242E8DC31EED5AB2005935FB /* RelativePositionMultipleViewsSpec.swift in Sources */,
 				2469C5041E75DB7600073BEE /* RectNimbleMatcher.swift in Sources */,
 				242723731F008BF7006A5C3A /* MinMaxWidthHeightSpec.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@
   <a href=""><img src="https://img.shields.io/cocoapods/p/PinLayout.svg?style=flat" /></a>
   <a href="https://travis-ci.org/mirego/PinLayout"><img src="https://travis-ci.org/mirego/PinLayout.svg?branch=master" /></a>
   <a href="https://codecov.io/gh/mirego/PinLayout"><img src="https://codecov.io/gh/mirego/PinLayout/branch/master/graph/badge.svg"/></a>
-  <a href='https://img.shields.io/cocoapods/v/PinLayout.svg'><img src="https://img.shields.io/cocoapods/v/PinLayout.svg" /></a>
   <a href="https://github.com/Carthage/Carthage"><img src="https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat" /></a>
   <a href="https://raw.githubusercontent.com/mirego/PinLayout/master/LICENSE"><img src="https://img.shields.io/badge/license-New%20BSD-blue.svg?style=flat" /></a>
-  <!--a href="https://github.com/mirego/PinLayout/issues"><img src="https://img.shields.io/github/issues/mirego/PinLayout.svg?style=flat" /></a-->
+  <a href="https://github.com/mirego/PinLayout/issues"><img src="https://img.shields.io/github/issues/mirego/PinLayout.svg?style=flat" /></a>
+</p>
+<p align="center">
+  <a href='https://cocoapods.org/pods/PinLayout'><img src="https://img.shields.io/cocoapods/v/PinLayout.svg" /></a>
+  <a href='https://cocoapods.org/pods/PinLayout'><img src="https://img.shields.io/cocoapods/dm/PinLayout.svg" /></a>
+  <a href='https://cocoapods.org/pods/PinLayout'><img src="https://img.shields.io/cocoapods/dt/PinLayout.svg" /></a>
 </p>
 
 Extremely Fast views layouting without auto layout. No magic, pure code, full control and blazing fast. Concise syntax, intuitive, readable & chainable.
@@ -174,7 +178,7 @@ A view can be layouted using PinLayout and later with another method/framework.
 
 # PinLayout's Performance <a name="performance"></a>
 
-PinLayout's performance has been measured using the [Layout Framework Benchmark](https://github.com/lucdion/LayoutFrameworkBenchmark). FlexLayout and [PinLayout](https://github.com/mirego/PinLayout) has been added to this benchmark to compare their performance. 
+PinLayout's performance has been measured using the [Layout Framework Benchmark](https://github.com/layoutBox/LayoutFrameworkBenchmark). FlexLayout and [PinLayout](https://github.com/mirego/PinLayout) has been added to this benchmark to compare their performance. 
 
 As you can see in the following chart, PinLayout and FlexLayout and performance are faster or equal to manual layouting, and **between 12x and 16x faster than auto layout**, and this for all types of iPhone (5/6/6S/7)
 

--- a/Sources/Impl/Coordinates.swift
+++ b/Sources/Impl/Coordinates.swift
@@ -75,6 +75,18 @@ class Coordinates {
                       width: ceilFloatToDisplayScale(rect.size.width),
                       height: ceilFloatToDisplayScale(rect.size.height))
     }
+    
+    static func setViewRectUsingDisplayScale(view: UIView, toRect rect: CGRect) {
+        /*
+         To adjust the view's position and size, we don't set the UIView's frame directly, because we want to keep the
+         view's transform (UIView.transform).
+         By setting the view's center and bounds we really set the frame of the non-transformed view, and this keep
+         the view's transform. So view's transforms won't be affected/altered by PinLayout.
+         */
+        let adjustedRect = Coordinates.adjustRectToDisplayScale(rect)
+        view.center = CGPoint(x: adjustedRect.midX, y: adjustedRect.midY)
+        view.bounds = CGRect(origin: .zero, size: adjustedRect.size)
+    }
 
     static func roundFloatToDisplayScale(_ pointValue: CGFloat) -> CGFloat {
         return CGFloat(roundf(Float(pointValue * displayScale))) / displayScale

--- a/Sources/Impl/PinLayoutImpl+Layouting.swift
+++ b/Sources/Impl/PinLayoutImpl+Layouting.swift
@@ -121,7 +121,13 @@ extension PinLayoutImpl {
             newRect.size.height = view.frame.height
         }
         
-        view.frame = Coordinates.adjustRectToDisplayScale(newRect)
+        /*
+         To adjust the view's position and size, we don't set the UIView's frame directly, because we want to keep the
+         view's transform (UIView.transform).
+         By setting the view's center and bounds we really set the frame of the non-transformed view, and this keep
+         the view's transform. So view's transforms won't be affected/altered by PinLayout.
+        */
+        Coordinates.setViewRectUsingDisplayScale(view: view, toRect: newRect)
     }
     
     private func handlePinEdges() {

--- a/Tests/BasicView.swift
+++ b/Tests/BasicView.swift
@@ -32,6 +32,7 @@ class BasicView: UIView {
         label.text = text
         label.font = UIFont.systemFont(ofSize: 7)
         label.textColor = .white
+        label.sizeToFit()
         addSubview(label)
     }
 
@@ -42,7 +43,7 @@ class BasicView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
             
-        label.pin.top().left().fitSize()
+        label.pin.top().left()
     }
     
     var sizeThatFitsExpectedArea: CGFloat = 40 * 40

--- a/Tests/TransformSpec.swift
+++ b/Tests/TransformSpec.swift
@@ -1,0 +1,70 @@
+//  Copyright (c) 2017 Luc Dion
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Quick
+import Nimble
+import PinLayout
+
+class TransformSpec: QuickSpec {
+    override func spec() {
+        var viewController: UIViewController!
+        
+        var rootView: BasicView!
+        var aView: BasicView!
+        
+        /*
+          root
+           |
+            - aView
+                |
+                 - aViewChild
+        */
+
+        beforeEach {
+            viewController = UIViewController()
+            
+            rootView = BasicView(text: "", color: .white)
+            rootView.frame = CGRect(x: 0, y: 0, width: 400, height: 400)
+            viewController.view.addSubview(rootView)
+            
+            aView = BasicView(text: "View A", color: UIColor.red.withAlphaComponent(0.5))
+            aView.frame = CGRect(x: 140, y: 100, width: 200, height: 120)
+            rootView.addSubview(aView)
+        }
+
+        describe("Layout the view ") {
+            it("without UIView.transform") {
+                aView.pin.top(100).left(100).width(100).height(50)
+                expect(aView.frame).to(equal(CGRect(x: 100, y: 100, width: 100.0, height: 50.0)))
+            }
+            
+            it("without UIView.transform") {
+                aView.transform = CGAffineTransform(scaleX: 2, y: 2)
+                aView.pin.top(100).left(100).width(100).height(50)
+
+                // The view should keep its transform
+                expect(aView.frame).to(equal(CGRect(x: 50.0, y: 75.0, width: 200.0, height: 100.0)))
+                
+                // If we clear the transform, the view should retrieve the original frame.
+                aView.transform = CGAffineTransform.identity
+                expect(aView.frame).to(equal(CGRect(x: 100, y: 100, width: 100.0, height: 50.0)))
+            }
+        }
+    }
+}

--- a/docs/Benchmark.md
+++ b/docs/Benchmark.md
@@ -13,13 +13,13 @@
 ## Methodology  <a name="methodology"></a>
 
 ##### LayoutKit Benchmark
-PinLayout and [FlexLayout](https://github.com/lucdion/FlexLayout) performance has been benchmarked using [Layout Framework Benchmark](https://github.com/lucdion/LayoutFrameworkBenchmark). 
+PinLayout and [FlexLayout](https://github.com/layoutBox/FlexLayout) performance has been benchmarked using [Layout Framework Benchmark](https://github.com/layoutBox/LayoutFrameworkBenchmark). 
 
 The benchmark include the following layout frameworks:
 
 * Auto layout
 * Manual layout (i.e. set UIView's frame directly)
-* [FlexLayout](https://github.com/lucdion/FlexLayout)
+* [FlexLayout](https://github.com/layoutBox/FlexLayout)
 * [PinLayout](https://github.com/mirego/PinLayout)
 * [LayoutKit](https://github.com/linkedin/LayoutKit)
 * UIStackViews
@@ -84,7 +84,7 @@ Remark how PinLayout and FlexLayout code is concise and clean compared to Manual
 
 ### PinLayout source code
 
-[PinLayout benchmark's source code](https://github.com/lucdion/LayoutFrameworkBenchmark/blob/master/LayoutFrameworkBenchmark/Benchmarks/PinLayout/FeedItemPinLayoutView.swift)
+[PinLayout benchmark's source code](https://github.com/layoutBox/LayoutFrameworkBenchmark/blob/master/LayoutFrameworkBenchmark/Benchmarks/PinLayout/FeedItemPinLayoutView.swift)
 
 ```swift
 override func layoutSubviews() {
@@ -122,7 +122,7 @@ override func layoutSubviews() {
 
 ### FlexLayout source code
 
-[FlexLayout benchmark's source code](https://github.com/lucdion/LayoutFrameworkBenchmark/blob/master/LayoutFrameworkBenchmark/Benchmarks/FlexLayout/FeedItemFlexLayoutView.swift)
+[FlexLayout benchmark's source code](https://github.com/layoutBox/LayoutFrameworkBenchmark/blob/master/LayoutFrameworkBenchmark/Benchmarks/FlexLayout/FeedItemFlexLayoutView.swift)
 
 ```swift
 flex.addItem(contentView).padding(8).define { (flex) in
@@ -166,7 +166,7 @@ flex.addItem(contentView).padding(8).define { (flex) in
 
 ### Manual layout source code
 
-[Manual layout benchmark's source code](https://github.com/lucdion/LayoutFrameworkBenchmark/blob/master/LayoutFrameworkBenchmark/Benchmarks/ManualLayout/FeedItemManualView.swift)
+[Manual layout benchmark's source code](https://github.com/layoutBox/LayoutFrameworkBenchmark/blob/master/LayoutFrameworkBenchmark/Benchmarks/ManualLayout/FeedItemManualView.swift)
 
 ```swift 
 override func layoutSubviews() {
@@ -241,6 +241,6 @@ override func layoutSubviews() {
 
 ### Auto layout source code
 
-[Auto layout benchmark's source code](https://github.com/lucdion/LayoutFrameworkBenchmark/blob/master/LayoutFrameworkBenchmark/Benchmarks/AutoLayout/FeedItemAutoLayoutView.swift)
+[Auto layout benchmark's source code](https://github.com/layoutBox/LayoutFrameworkBenchmark/blob/master/LayoutFrameworkBenchmark/Benchmarks/AutoLayout/FeedItemAutoLayoutView.swift)
 
 <br>


### PR DESCRIPTION
By setting the view's center and bounds we set the frame of the non-transformed view, and this keeps the view's transform.
So view's transforms won't be affected/altered anymore by PinLayout.

For people not using transforms, this should be a non-breaking change. If someone is using transforms with PinLayout, this may change the behavior, although I think this will produce the expected results (ie, transforms not being affected/altered by layout).