### PR TITLE
Add few missing Objective-C Interface properties and methods

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,6 +20,7 @@ disabled_rules: # rule identifiers to exclude from running
   - nimble_operator
   - identifier_name
   - line_length
+  - empty_count
 
 excluded: # paths to ignore during linting. overridden by `included`.
   - Pods

--- a/Example/.swiftlint.yml
+++ b/Example/.swiftlint.yml
@@ -20,6 +20,7 @@ disabled_rules: # rule identifiers to exclude from running
   - nimble_operator
   - identifier_name
   - line_length
+  - empty_count
 
 excluded: # paths to ignore during linting. overridden by `included`.
   - Pods

--- a/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCViewController.m
+++ b/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCViewController.m
@@ -21,13 +21,14 @@
 #import "IntroObjectiveCViewController.h"
 
 #import "IntroObjectiveCView.h"
+@import PinLayout;
 
 @implementation IntroObjectiveCViewController {
 }
 
 - (id) init {
     if (self = [super init]){
-        
+        Pin.safeAreaInsetsDidChangeMode = PinSafeAreaInsetsDidChangeModeAlways;
     }
     return self;
 }

--- a/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCViewController.m
+++ b/Example/PinLayoutSample/UI/Examples/IntroObjectiveC/IntroObjectiveCViewController.m
@@ -21,14 +21,13 @@
 #import "IntroObjectiveCViewController.h"
 
 #import "IntroObjectiveCView.h"
-@import PinLayout;
 
 @implementation IntroObjectiveCViewController {
 }
 
 - (id) init {
     if (self = [super init]){
-        Pin.safeAreaInsetsDidChangeMode = PinSafeAreaInsetsDidChangeModeAlways;
+        
     }
     return self;
 }

--- a/Sources/Pin.swift
+++ b/Sources/Pin.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-public enum LayoutDirection {
+@objc public enum LayoutDirection: Int {
     case auto
     case ltr
     case rtl
@@ -28,7 +28,7 @@ public enum LayoutDirection {
 /// Control how PinLayout will calls `UIView.safeAreaInsetsDidChange` when the `UIView.pin.safeArea` change.
 /// This support is usefull only on iOS 8/9/10. On iOS 11 `UIView.safeAreaInsetsDidChange` is supported
 /// natively so this settings have no impact.
-public enum PinSafeAreaInsetsDidChangeMode {
+@objc public enum PinSafeAreaInsetsDidChangeMode: Int {
     /// PinLayout won't call `UIView.safeAreaInsetsDidChange` on iOS 8/9/10.
     case disable
     /// PinLayout will call `UIView.safeAreaInsetsDidChange` only if the UIView implement the PinSafeAreaInsetsUpdate protocol.
@@ -38,11 +38,11 @@ public enum PinSafeAreaInsetsDidChangeMode {
 }
 
 @objc public class Pin: NSObject {
-    public static var layoutDirection = LayoutDirection.ltr
+    @objc public static var layoutDirection = LayoutDirection.ltr
 
     #if os(iOS) || os(tvOS)
     /// Controls how PinLayout will calls `UIView.safeAreaInsetsDidChange` when the `UIView.pin.safeArea` change.
-    public static var safeAreaInsetsDidChangeMode: PinSafeAreaInsetsDidChangeMode = .optIn {
+    @objc public static var safeAreaInsetsDidChangeMode: PinSafeAreaInsetsDidChangeMode = .optIn {
         didSet {
             PinSafeArea.safeAreaInsetsDidChangeMode = safeAreaInsetsDidChangeMode
         }
@@ -51,9 +51,9 @@ public enum PinSafeAreaInsetsDidChangeMode {
 
 
 #if DEBUG
-    public static var logWarnings = true
+    @objc public static var logWarnings = true
 #else
-    public static var logWarnings = false
+    @objc public static var logWarnings = false
 #endif
     
     /**
@@ -65,7 +65,7 @@ public enum PinSafeAreaInsetsDidChangeMode {
 
     static fileprivate var isInitialized = false
 
-    public static func initPinLayout() {
+    @objc public static func initPinLayout() {
         #if os(iOS) || os(tvOS)
         guard !Pin.isInitialized else { return }
         PinSafeArea.initSafeAreaSupport()
@@ -73,7 +73,7 @@ public enum PinSafeAreaInsetsDidChangeMode {
         #endif
     }
 
-    public static func layoutDirection(_ direction: LayoutDirection) {
+    @objc public static func layoutDirection(_ direction: LayoutDirection) {
         self.layoutDirection = direction
     }
 

--- a/Tests/iOS/ObjectiveCSpec.m
+++ b/Tests/iOS/ObjectiveCSpec.m
@@ -38,8 +38,16 @@ describe(@"test Objective-C interface", ^{
         Pin.logMissingLayoutCalls = false;
     });
     
-    describe(@"its click", ^{
-        it(@"is loud", ^{
+    describe(@"generic objective-c tests", ^{
+        it(@"Access Pin properties and methods", ^{
+            [Pin initPinLayout];
+            [Pin layoutDirection:LayoutDirectionLtr];
+            Pin.safeAreaInsetsDidChangeMode = PinSafeAreaInsetsDidChangeModeAlways;
+            Pin.layoutDirection = LayoutDirectionLtr;
+            Pin.logWarnings = true;
+        });
+
+        it(@"basic pinlayout calls", ^{
             [[[aView pinObjc] top:10] layout];
             expect(@(aView.frame)).to(equal(@(CGRectMake(40, 10, 100, 60))));
         });


### PR DESCRIPTION
These methods and properties are now accessible from Objective-C:
* `Pin.layoutDirection`
* `Pin.safeAreaInsetsDidChangeMode`
* `Pin.logWarnings`
* `Pin.initPinLayout()`
* `Pin.layoutDirection()`